### PR TITLE
[chore] Swagger-UI 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ _(추후 작성)_
 - Spring Data JPA + Flyway
 - Gradle
 - Docker / Docker Compose
+- Swagger UI (springdoc-openapi)
 
 ## 실행 방법
 
@@ -32,6 +33,9 @@ cd ../enrollment-api
 # 3. 헬스체크
 curl http://localhost:8080/actuator/health
 # {"status":"UP",...}
+
+# 4. Swagger UI 접근
+open http://localhost:8080/swagger-ui/index.html
 ```
 
 ## API 목록 및 예시

--- a/enrollment-api/build.gradle
+++ b/enrollment-api/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
     runtimeOnly   'org.postgresql:postgresql'
 
+    // Swagger / OpenAPI (API 문서 자동화)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
     compileOnly         'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly         'org.projectlombok:lombok'

--- a/enrollment-api/src/main/java/com/enrollment/global/config/SwaggerConfig.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.enrollment.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("수강 신청 시스템 API")
+                        .version("v1.0")
+                        .description("Spring Boot 3.3 기반 수강 신청 시스템 백엔드 API 문서"));
+    }
+}


### PR DESCRIPTION
## Summary
- springdoc-openapi 도입, `@RestController` 추가 시 자동으로 `/v3/api-docs` 반영

<img width="617" height="583" alt="image" src="https://github.com/user-attachments/assets/b6c3cd66-6379-4050-9307-0bddff4e0a9f" />

close #4

## 변경 사항

| 파일 | 내용 |
|------|------|
| `enrollment-api/build.gradle` | `springdoc-openapi-starter-webmvc-ui:2.6.0` (Spring Boot 3.3 호환) |
| `enrollment-api/src/main/java/com/enrollment/global/config/SwaggerConfig.java` | `OpenAPI` bean (title/version/description) |
| `README.md` | 기술 스택에 Swagger UI 추가, 실행 방법에 `/swagger-ui/index.html` 단계 포함 |

## 테스트 결과
- [x] `./gradlew build` 성공
- [x] `EnrollmentApplicationTests.contextLoads` PASS (SwaggerConfig bean 초기화 포함)
- [x] `docker-compose up -d` + `./gradlew bootRun` 8080 기동
- [x] `curl /v3/api-docs` OpenAPI 3.0.1 JSON, `title="수강 신청 시스템 API"` 응답
- [x] `curl -I /swagger-ui/index.html` 200 OK
- [x] `curl -I /swagger-ui.html` 302 리다이렉트
- [x] `/actuator/health` 여전히 UP

## 영향 범위
- 도메인/런타임 코드 변경 0건, 문서 인프라만 추가
