### PR TITLE
[chore] 공통 에러 응답 인프라 구축

### DIFF
--- a/enrollment-api/src/main/java/com/enrollment/global/error/ErrorResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.enrollment.global.error;
+
+import com.enrollment.global.error.exception.ErrorCode;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+        String code,
+        String message,
+        LocalDateTime timestamp,
+        String path
+) {
+
+    public static ErrorResponse of(ErrorCode errorCode, String path) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), LocalDateTime.now(), path);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message, String path) {
+        return new ErrorResponse(errorCode.getCode(), message, LocalDateTime.now(), path);
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/error/GlobalExceptionHandler.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,53 @@
+package com.enrollment.global.error;
+
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e, HttpServletRequest request) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn("BusinessException: code={}, path={}", errorCode.getCode(), request.getRequestURI());
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.of(errorCode, request.getRequestURI()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        String detail = e.getBindingResult().getFieldErrors().stream()
+                .sorted(Comparator.comparing(FieldError::getField))
+                .map(fe -> fe.getField() + ": " + defaultIfNull(fe.getDefaultMessage()))
+                .collect(Collectors.joining("; "));
+        log.warn("Validation failed: {}", detail);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, detail, request.getRequestURI()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception e, HttpServletRequest request) {
+        log.error("Unexpected exception at {}", request.getRequestURI(), e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_ERROR.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_ERROR, request.getRequestURI()));
+    }
+
+    private static String defaultIfNull(String message) {
+        return message == null ? "invalid" : message;
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/error/exception/BusinessException.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.enrollment.global.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.enrollment.global.error.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력값이 올바르지 않습니다"),
+    CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "CAPACITY_EXCEEDED", "정원이 초과되었습니다"),
+    CANCEL_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "CANCEL_PERIOD_EXPIRED", "취소 가능 기간(7일)을 초과했습니다"),
+    ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "ALREADY_CANCELLED", "이미 취소된 수강 신청입니다"),
+    INVALID_STATE_TRANSITION(HttpStatus.BAD_REQUEST, "INVALID_STATE_TRANSITION", "허용되지 않은 상태 전이입니다"),
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다"),
+
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "권한이 없습니다"),
+    NOT_COURSE_OWNER(HttpStatus.FORBIDDEN, "NOT_COURSE_OWNER", "해당 강의의 소유자가 아닙니다"),
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다"),
+    CLASS_NOT_FOUND(HttpStatus.NOT_FOUND, "CLASS_NOT_FOUND", "강의를 찾을 수 없습니다"),
+    ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ENROLLMENT_NOT_FOUND", "수강 신청 내역을 찾을 수 없습니다"),
+
+    ALREADY_ENROLLED(HttpStatus.CONFLICT, "ALREADY_ENROLLED", "이미 신청한 강의입니다"),
+
+    LOCK_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "LOCK_TIMEOUT", "요청이 혼잡합니다. 잠시 후 다시 시도해주세요"),
+
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,79 @@
+package com.enrollment.global.error;
+
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.*;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@Import({GlobalExceptionHandler.class, GlobalExceptionHandlerTest.TestController.class})
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void BusinessException_시_ErrorCode의_HttpStatus와_포맷으로_응답() throws Exception {
+        mockMvc.perform(get("/test/business"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("CAPACITY_EXCEEDED"))
+                .andExpect(jsonPath("$.message").value("정원이 초과되었습니다"))
+                .andExpect(jsonPath("$.path").value("/test/business"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    void Valid_실패_시_400_INVALID_INPUT_필드에러_집약_메시지() throws Exception {
+        String body = "{\"title\":\"\",\"price\":-1}";
+        mockMvc.perform(post("/test/valid").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message", containsString("price")))
+                .andExpect(jsonPath("$.message", containsString("title")))
+                .andExpect(jsonPath("$.path").value("/test/valid"));
+    }
+
+    @Test
+    void 예상외_예외_시_500_INTERNAL_ERROR() throws Exception {
+        mockMvc.perform(get("/test/unexpected"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("INTERNAL_ERROR"))
+                .andExpect(jsonPath("$.path").value("/test/unexpected"));
+    }
+
+    @RestController
+    @RequestMapping("/test")
+    static class TestController {
+
+        @GetMapping("/business")
+        public void business() {
+            throw new BusinessException(ErrorCode.CAPACITY_EXCEEDED);
+        }
+
+        @PostMapping("/valid")
+        public void valid(@RequestBody @Valid Payload payload) {
+        }
+
+        @GetMapping("/unexpected")
+        public void unexpected() {
+            throw new IllegalStateException("boom");
+        }
+
+        record Payload(@NotBlank String title, @Positive int price) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 전역 에러 응답 포맷 통일: `{code, message, timestamp, path}`
- 도메인 예외는 `BusinessException` 단일 통로, Controller try-catch 제거
- ErrorCode enum 14종 카탈로그화 (오타/누락 가시성)

close #7

## 변경 사항

| 파일 | 내용 |
|------|------|
| `global/error/exception/ErrorCode.java` | 14종 enum (HttpStatus, code, defaultMessage) |
| `global/error/exception/BusinessException.java` | RuntimeException 상속, ErrorCode 단일 생성자 |
| `global/error/ErrorResponse.java` | record (code/message/timestamp/path), 정적 팩토리 `of()` |
| `global/error/GlobalExceptionHandler.java` | `@RestControllerAdvice`, 3 핸들러 |
| `test/.../GlobalExceptionHandlerTest.java` | `@WebMvcTest`, 더미 TestController 3 시나리오 |

### ErrorCode 14종
- 400: INVALID_INPUT, CAPACITY_EXCEEDED, CANCEL_PERIOD_EXPIRED, ALREADY_CANCELLED, INVALID_STATE_TRANSITION
- 401: UNAUTHORIZED
- 403: FORBIDDEN, NOT_COURSE_OWNER
- 404: USER_NOT_FOUND, CLASS_NOT_FOUND, ENROLLMENT_NOT_FOUND
- 409: ALREADY_ENROLLED
- 503: LOCK_TIMEOUT
- 500: INTERNAL_ERROR

### 핸들러 3종
- `BusinessException` → ErrorCode.httpStatus 응답
- `MethodArgumentNotValidException` → 400 + INVALID_INPUT, 필드 에러 집약(필드명 sorted)
- `Exception` → 500 + INTERNAL_ERROR

## 테스트 결과
- [x] `GlobalExceptionHandlerTest` 3/3 통과
  - BusinessException 응답 포맷과 HttpStatus 검증
  - `@Valid` 실패 시 400 + INVALID_INPUT, 필드 에러 메시지 확인
  - 예상 외 예외 시 500 + INTERNAL_ERROR
- [x] `contextLoads` 통과
- [x] BUILD SUCCESSFUL

## 영향 범위
- 이후 도메인에서 도메인 예외는 `throw new BusinessException(ErrorCode.XXX)` 한 줄로 통일
- Controller 레이어에 try-catch 불필요
- DB 마이그레이션 없음
