### PR TITLE
[feat] User 도메인 + JPA 인프라 기반 구축

### DIFF
--- a/enrollment-api/build.gradle
+++ b/enrollment-api/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:junit-jupiter'
     testRuntimeOnly    'org.junit.platform:junit-platform-launcher'
 }
 

--- a/enrollment-api/src/main/java/com/enrollment/domain/user/entity/User.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/user/entity/User.java
@@ -1,0 +1,37 @@
+package com.enrollment.domain.user.entity;
+
+import com.enrollment.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/user/entity/UserRole.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/user/entity/UserRole.java
@@ -1,0 +1,9 @@
+package com.enrollment.domain.user.entity;
+
+/**
+ * 사용자 역할. CREATOR = 강사, CLASSMATE = 수강생
+ */
+public enum UserRole {
+    CREATOR,
+    CLASSMATE
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/user/repository/UserRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.enrollment.domain.user.repository;
+
+import com.enrollment.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/config/JpaAuditingConfig.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.enrollment.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/entity/BaseEntity.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.enrollment.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/error/GlobalExceptionHandler.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/enrollment-api/src/main/resources/db/migration/V1__create_users_table.sql
+++ b/enrollment-api/src/main/resources/db/migration/V1__create_users_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE users (
+    user_id    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name       VARCHAR(50) NOT NULL,
+    role       VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    updated_at TIMESTAMP(6) NOT NULL
+);

--- a/enrollment-api/src/test/java/com/enrollment/EnrollmentApplicationTests.java
+++ b/enrollment-api/src/test/java/com/enrollment/EnrollmentApplicationTests.java
@@ -1,10 +1,11 @@
 package com.enrollment;
 
+import com.enrollment.support.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class EnrollmentApplicationTests {
+class EnrollmentApplicationTests extends AbstractIntegrationTest {
     @Test
     void contextLoads() {
     }

--- a/enrollment-api/src/test/java/com/enrollment/domain/user/UserRepositoryTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/user/UserRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.enrollment.domain.user;
+
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.config.JpaAuditingConfig;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Import(JpaAuditingConfig.class)
+class UserRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    TestEntityManager em;
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    void save_시_id_자동_생성() {
+        User saved = userRepository.saveAndFlush(
+            User.builder().name("kim").role(UserRole.CLASSMATE).build()
+        );
+        assertThat(saved.getId()).isNotNull();
+    }
+
+    @Test
+    void findById_왕복() {
+        Long id = userRepository.saveAndFlush(
+            User.builder().name("kim").role(UserRole.CLASSMATE).build()
+        ).getId();
+        em.clear();
+        User found = userRepository.findById(id).orElseThrow();
+        assertThat(found.getName()).isEqualTo("kim");
+        assertThat(found.getRole()).isEqualTo(UserRole.CLASSMATE);
+    }
+
+    @Test
+    void Auditing_자동_주입() {
+        User saved = userRepository.saveAndFlush(
+            User.builder().name("kim").role(UserRole.CREATOR).build()
+        );
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void name_null_시_제약_위반() {
+        User invalid = User.builder().role(UserRole.CLASSMATE).build();
+        assertThatThrownBy(() -> userRepository.saveAndFlush(invalid))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/support/AbstractIntegrationTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/support/AbstractIntegrationTest.java
@@ -1,0 +1,15 @@
+package com.enrollment.support;
+
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public abstract class AbstractIntegrationTest {
+
+    @ServiceConnection
+    protected static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static {
+        POSTGRES.start();
+    }
+}

--- a/enrollment-api/src/test/resources/application.yml
+++ b/enrollment-api/src/test/resources/application.yml
@@ -1,6 +1,0 @@
-spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration


### PR DESCRIPTION
close #10

## Summary
후속 도메인(Class, Enrollment, Payment) FK 대상 `users` 테이블 + 엔티티 공통 기반(BaseEntity, JPA Auditing, Flyway, Testcontainers) 동시 셋업.

## 변경 사항

| 파일 | 내용 |
|------|------|
| `global/entity/BaseEntity.java` | `@MappedSuperclass`, `@CreatedDate` / `@LastModifiedDate` |
| `global/config/JpaAuditingConfig.java` | `@Configuration @EnableJpaAuditing` |
| `domain/user/entity/User.java` | id(IDENTITY), name, role(`@Enumerated STRING`), BaseEntity |
| `domain/user/entity/UserRole.java` | CREATOR(강사), CLASSMATE(수강생) |
| `domain/user/repository/UserRepository.java` | JpaRepository<User, Long> |
| `db/migration/V1__create_users_table.sql` | BIGINT IDENTITY PK, TIMESTAMP(6), 시드 없음 |
| `build.gradle` | Testcontainers 의존성 3종 (test scope) |
| `test/support/AbstractIntegrationTest.java` | Testcontainers postgres:15-alpine 싱글톤 |
| `test/domain/user/UserRepositoryTest.java` | 4 테스트 (save/findById/Auditing/NOT NULL 제약) |
| `EnrollmentApplicationTests.java` | AbstractIntegrationTest 상속 |
| `test/resources/application.yml` | 삭제 (Testcontainers 통합으로 exclude 불필요) |

## 테스트 결과
- [x] UserRepositoryTest 4/4
- [x] EnrollmentApplicationTests.contextLoads 1/1
- [x] GlobalExceptionHandlerTest 3/3 (회귀 없음)
- [x] BUILD SUCCESSFUL (`--rerun-tasks`)

## 영향 범위
- 이후 Class, Enrollment 도메인에서 User FK 참조 가능
- 모든 후속 엔티티는 `extends BaseEntity`로 Auditing 자동 확보
- 이후 Repository 테스트는 `extends AbstractIntegrationTest`로 Testcontainers 재사용
