### PR TITLE
[feat] Enrollment(수강 신청) 도메인 + 결제 시뮬레이션 구현

### DIFF
--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
@@ -5,6 +5,8 @@ import com.enrollment.domain.classes.dto.ClassResponse;
 import com.enrollment.domain.classes.dto.ClassUpdateRequest;
 import com.enrollment.domain.classes.entity.ClassStatus;
 import com.enrollment.domain.classes.service.ClassService;
+import com.enrollment.domain.enrollment.dto.EnrollmentWithUserResponse;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
 import com.enrollment.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -38,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ClassController {
 
     private final ClassService classService;
+    private final EnrollmentService enrollmentService;
 
     @Operation(summary = "강의 등록", description = "새로운 강의를 등록합니다.")
     @ApiResponses(value = {
@@ -169,5 +172,25 @@ public class ClassController {
             @RequestHeader("X-User-Id") Long userId,
             @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(classService.getMyClasses(userId, pageable));
+    }
+
+    @Operation(summary = "강의별 수강생 목록 조회", description = "강사 본인의 강의에 등록된 수강생 목록을 페이지 단위로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "수강생 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = Page.class))),
+        @ApiResponse(responseCode = "403", description = "강의 소유자가 아님 (NOT_COURSE_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음 (CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{id}/enrollments")
+    public ResponseEntity<Page<EnrollmentWithUserResponse>> getClassEnrollments(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id,
+            @ParameterObject @PageableDefault(size = 20, sort = "enrolledAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(enrollmentService.getClassEnrollments(userId, id, pageable));
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
@@ -70,17 +70,20 @@ public class ClassEntity extends BaseEntity {
     @Version
     private Long version;
 
+    // 강의 공개
     public void publish() {
         validateTransition(ClassStatus.OPEN);
         validateFieldsForPublish();
         this.status = ClassStatus.OPEN;
     }
 
+    // 강의 모집 마감
     public void close() {
         validateTransition(ClassStatus.CLOSED);
         this.status = ClassStatus.CLOSED;
     }
 
+    // 강의 수정
     public void update(String title, String description, Integer price,
                        Integer capacity, LocalDate startDate, LocalDate endDate) {
         if (this.status != ClassStatus.DRAFT) {
@@ -105,18 +108,37 @@ public class ClassEntity extends BaseEntity {
         }
     }
 
+    // 강의 소유자 검증
     public void validateOwner(Long userId) {
         if (this.createdBy == null || !this.createdBy.getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NOT_COURSE_OWNER);
         }
     }
 
+    // 수강생 수 증가
+    public void incrementEnrolled() {
+        if (this.enrolledCount >= this.capacity) {
+            throw new BusinessException(ErrorCode.CAPACITY_EXCEEDED);
+        }
+        this.enrolledCount++;
+    }
+
+    // 수강생 수 감소
+    public void decrementEnrolled() {
+        if (this.enrolledCount <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        this.enrolledCount--;
+    }
+
+    // 상태 전환 검증
     private void validateTransition(ClassStatus target) {
         if (!this.status.canTransitionTo(target)) {
             throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
         }
     }
 
+    // 강의 공개 필드 검증
     private void validateFieldsForPublish() {
         if (price == null || price < 0) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassStatus.java
@@ -3,6 +3,7 @@ package com.enrollment.domain.classes.entity;
 public enum ClassStatus {
     DRAFT, OPEN, CLOSED;
 
+    // 상태 전환 가능 여부 검증
     public boolean canTransitionTo(ClassStatus target) {
         return switch (this) {
             case DRAFT -> target == OPEN;

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/repository/ClassRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/repository/ClassRepository.java
@@ -15,16 +15,20 @@ import java.util.Optional;
 
 public interface ClassRepository extends JpaRepository<ClassEntity, Long> {
 
+    // 강의 조회
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM ClassEntity c JOIN FETCH c.createdBy WHERE c.id = :id")
     Optional<ClassEntity> findByIdForUpdate(@Param("id") Long id);
 
+    // 강의 소유자 조회
     @EntityGraph(attributePaths = "createdBy")
     Optional<ClassEntity> findWithCreatorById(Long id);
 
+    // 강의 상태별 목록 조회
     @EntityGraph(attributePaths = "createdBy")
     Page<ClassEntity> findByStatus(ClassStatus status, Pageable pageable);
 
+    // 강의 소유자별 목록 조회
     @EntityGraph(attributePaths = "createdBy")
     Page<ClassEntity> findByCreatedById(Long userId, Pageable pageable);
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
@@ -14,6 +14,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -48,5 +50,49 @@ public class EnrollmentController {
             @RequestHeader("X-User-Id") Long userId,
             @RequestBody @Valid EnrollmentCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(enrollmentService.enroll(userId, request));
+    }
+
+    @Operation(summary = "결제", description = "수강 신청을 결제하여 CONFIRMED 상태로 전환합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "결제 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = EnrollmentResponse.class))),
+        @ApiResponse(responseCode = "400", description = "이미 확정/취소된 신청 또는 잘못된 상태 전환 (INVALID_STATE_TRANSITION)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "수강 신청 소유자가 아님 (NOT_ENROLLMENT_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "수강 신청을 찾을 수 없음 (ENROLLMENT_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PatchMapping("/{id}/pay")
+    public ResponseEntity<EnrollmentResponse> pay(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id) {
+        return ResponseEntity.ok(enrollmentService.pay(userId, id));
+    }
+
+    @Operation(summary = "수강 취소", description = "수강 신청을 취소합니다. CONFIRMED 상태라면 7일 이내에만 가능하며 환불 처리됩니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "취소 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = EnrollmentResponse.class))),
+        @ApiResponse(responseCode = "400", description = "취소 가능 기간 초과 또는 이미 취소됨 (CANCEL_PERIOD_EXPIRED, ALREADY_CANCELLED)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "수강 신청 소유자가 아님 (NOT_ENROLLMENT_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "수강 신청을 찾을 수 없음 (ENROLLMENT_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PatchMapping("/{id}/cancel")
+    public ResponseEntity<EnrollmentResponse> cancel(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id) {
+        return ResponseEntity.ok(enrollmentService.cancel(userId, id));
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
@@ -1,0 +1,52 @@
+package com.enrollment.domain.enrollment.controller;
+
+import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
+import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Enrollment API", description = "수강 신청 관리 API")
+@RestController
+@RequestMapping("/enrollments")
+@RequiredArgsConstructor
+public class EnrollmentController {
+
+    private final EnrollmentService enrollmentService;
+
+    @Operation(summary = "수강 신청", description = "강의를 수강 신청합니다. 정원/중복 체크 후 PENDING 상태로 생성됩니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "수강 신청 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = EnrollmentResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 입력값 또는 상태 (INVALID_INPUT, INVALID_STATE_TRANSITION, CAPACITY_EXCEEDED)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자 또는 강의를 찾을 수 없음 (USER_NOT_FOUND, CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "409", description = "이미 신청한 강의 (ALREADY_ENROLLED)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping
+    public ResponseEntity<EnrollmentResponse> enroll(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestBody @Valid EnrollmentCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(enrollmentService.enroll(userId, request));
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
@@ -12,8 +12,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -94,5 +100,21 @@ public class EnrollmentController {
             @RequestHeader("X-User-Id") Long userId,
             @PathVariable Long id) {
         return ResponseEntity.ok(enrollmentService.cancel(userId, id));
+    }
+
+    @Operation(summary = "내 수강 신청 목록 조회", description = "현재 사용자의 수강 신청 목록을 페이지 단위로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "수강 신청 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = Page.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음 (USER_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/me")
+    public ResponseEntity<Page<EnrollmentResponse>> getMyEnrollments(
+            @RequestHeader("X-User-Id") Long userId,
+            @ParameterObject @PageableDefault(size = 20, sort = "enrolledAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(enrollmentService.getMyEnrollments(userId, pageable));
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentCreateRequest.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentCreateRequest.java
@@ -1,0 +1,8 @@
+package com.enrollment.domain.enrollment.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EnrollmentCreateRequest(
+        @NotNull Long classId
+) {
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentResponse.java
@@ -1,0 +1,28 @@
+package com.enrollment.domain.enrollment.dto;
+
+import com.enrollment.domain.enrollment.entity.Enrollment;
+
+import java.time.LocalDateTime;
+
+public record EnrollmentResponse(
+        Long enrollmentId,
+        Long classId,
+        String classTitle,
+        String status,
+        LocalDateTime enrolledAt,
+        LocalDateTime confirmedAt,
+        LocalDateTime cancelledAt
+) {
+
+    public static EnrollmentResponse from(Enrollment enrollment) {
+        return new EnrollmentResponse(
+                enrollment.getId(),
+                enrollment.getClassEntity().getId(),
+                enrollment.getClassEntity().getTitle(),
+                enrollment.getStatus().name(),
+                enrollment.getEnrolledAt(),
+                enrollment.getConfirmedAt(),
+                enrollment.getCancelledAt()
+        );
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentWithUserResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentWithUserResponse.java
@@ -1,0 +1,24 @@
+package com.enrollment.domain.enrollment.dto;
+
+import com.enrollment.domain.enrollment.entity.Enrollment;
+
+import java.time.LocalDateTime;
+
+public record EnrollmentWithUserResponse(
+        Long enrollmentId,
+        Long userId,
+        String userName,
+        String status,
+        LocalDateTime enrolledAt
+) {
+
+    public static EnrollmentWithUserResponse from(Enrollment enrollment) {
+        return new EnrollmentWithUserResponse(
+                enrollment.getId(),
+                enrollment.getUser().getId(),
+                enrollment.getUser().getName(),
+                enrollment.getStatus().name(),
+                enrollment.getEnrolledAt()
+        );
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
@@ -1,0 +1,95 @@
+package com.enrollment.domain.enrollment.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.global.entity.BaseEntity;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "enrollments")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Enrollment extends BaseEntity {
+
+    private static final int CANCEL_WINDOW_DAYS = 7;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "enrollment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "class_id", nullable = false)
+    private ClassEntity classEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private EnrollmentStatus status;
+
+    @Column(name = "enrolled_at", nullable = false)
+    private LocalDateTime enrolledAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    public void confirm() {
+        validateTransition(EnrollmentStatus.CONFIRMED);
+        this.status = EnrollmentStatus.CONFIRMED;
+        this.confirmedAt = LocalDateTime.now();
+    }
+
+    public void cancel() {
+        if (this.status == EnrollmentStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.ALREADY_CANCELLED);
+        }
+        if (this.status == EnrollmentStatus.CONFIRMED) {
+            if (this.confirmedAt == null
+                    || this.confirmedAt.plusDays(CANCEL_WINDOW_DAYS).isBefore(LocalDateTime.now())) {
+                throw new BusinessException(ErrorCode.CANCEL_PERIOD_EXPIRED);
+            }
+        }
+        validateTransition(EnrollmentStatus.CANCELLED);
+        this.status = EnrollmentStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    public void validateOwner(Long userId) {
+        if (this.user == null || !this.user.getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOT_ENROLLMENT_OWNER);
+        }
+    }
+
+    private void validateTransition(EnrollmentStatus target) {
+        if (!this.status.canTransitionTo(target)) {
+            throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/EnrollmentStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/EnrollmentStatus.java
@@ -1,0 +1,13 @@
+package com.enrollment.domain.enrollment.entity;
+
+public enum EnrollmentStatus {
+    PENDING, CONFIRMED, CANCELLED;
+
+    public boolean canTransitionTo(EnrollmentStatus target) {
+        return switch (this) {
+            case PENDING -> target == CONFIRMED || target == CANCELLED;
+            case CONFIRMED -> target == CANCELLED;
+            case CANCELLED -> false;
+        };
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,0 +1,43 @@
+package com.enrollment.domain.enrollment.repository;
+
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+    // 수강 신청 비관적 락 조회
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Enrollment e JOIN FETCH e.classEntity JOIN FETCH e.user WHERE e.id = :id")
+    Optional<Enrollment> findByIdForUpdate(@Param("id") Long id);
+
+    // 수강 신청 락 없는 조회 (classEntity, user 즉시 로딩)
+    @EntityGraph(attributePaths = {"classEntity", "user"})
+    Optional<Enrollment> findWithClassAndUserById(Long id);
+
+    // 사용자별 수강 신청 목록 조회
+    @EntityGraph(attributePaths = {"classEntity", "user"})
+    Page<Enrollment> findByUserId(Long userId, Pageable pageable);
+
+    // 강의별 수강 신청 목록 조회
+    @EntityGraph(attributePaths = {"classEntity", "user"})
+    Page<Enrollment> findByClassEntityId(Long classId, Pageable pageable);
+
+    // 수강 신청 존재 여부 검증
+    @Query("SELECT (COUNT(e) > 0) FROM Enrollment e "
+            + "WHERE e.classEntity.id = :classId AND e.user.id = :userId AND e.status IN :statuses")
+    boolean existsByClassIdAndUserIdAndStatusIn(
+            @Param("classId") Long classId,
+            @Param("userId") Long userId,
+            @Param("statuses") Collection<EnrollmentStatus> statuses);
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -1,0 +1,69 @@
+package com.enrollment.domain.enrollment.service;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
+import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EnrollmentService {
+
+    private static final List<EnrollmentStatus> ACTIVE_STATUSES =
+            List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED);
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final ClassRepository classRepository;
+    private final UserRepository userRepository;
+
+    // 수강 신청
+    @Transactional
+    public EnrollmentResponse enroll(Long userId, EnrollmentCreateRequest request) {
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 강의 조회
+        ClassEntity classEntity = classRepository.findByIdForUpdate(request.classId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 강의 상태 검증
+        if (classEntity.getStatus() != ClassStatus.OPEN) {
+            throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+
+        // 수강 신청 존재 여부 검증
+        if (enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                classEntity.getId(), user.getId(), ACTIVE_STATUSES)) {
+            throw new BusinessException(ErrorCode.ALREADY_ENROLLED);
+        }
+
+        // 좌석 차감
+        classEntity.incrementEnrolled();
+
+        // 수강 신청 저장
+        return EnrollmentResponse.from(enrollmentRepository.save(
+                Enrollment.builder()
+                        .classEntity(classEntity)
+                        .user(user)
+                        .status(EnrollmentStatus.PENDING)
+                        .enrolledAt(LocalDateTime.now())
+                        .build()));
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -7,7 +7,9 @@ import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
 import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
 import com.enrollment.domain.enrollment.entity.Enrollment;
 import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.payment.entity.Payment;
 import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.payment.repository.PaymentRepository;
 import com.enrollment.domain.user.entity.User;
 import com.enrollment.domain.user.repository.UserRepository;
 import com.enrollment.global.error.exception.BusinessException;
@@ -28,6 +30,7 @@ public class EnrollmentService {
             List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED);
 
     private final EnrollmentRepository enrollmentRepository;
+    private final PaymentRepository paymentRepository;
     private final ClassRepository classRepository;
     private final UserRepository userRepository;
 
@@ -65,5 +68,57 @@ public class EnrollmentService {
                         .status(EnrollmentStatus.PENDING)
                         .enrolledAt(LocalDateTime.now())
                         .build()));
+    }
+
+    // 결제
+    @Transactional
+    public EnrollmentResponse pay(Long userId, Long enrollmentId) {
+
+        // 수강 신청 조회 (본인 row 상태 변경만이라 락 불필요, 상태머신 + uk_payment_paid 부분 유니크 인덱스로 방어)
+        Enrollment enrollment = enrollmentRepository.findWithClassAndUserById(enrollmentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
+
+        // 수강 신청 소유자 검증
+        enrollment.validateOwner(userId);
+
+        // 수강 신청 확정
+        enrollment.confirm();
+
+        // 결제 저장
+        paymentRepository.save(Payment.paid(enrollment, enrollment.getClassEntity().getPrice()));
+
+        return EnrollmentResponse.from(enrollment);
+    }
+
+    // 수강 취소
+    @Transactional
+    public EnrollmentResponse cancel(Long userId, Long enrollmentId) {
+
+        // 수강 신청 조회
+        Enrollment enrollment = enrollmentRepository.findByIdForUpdate(enrollmentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
+
+        // 수강 신청 소유자 검증
+        enrollment.validateOwner(userId);
+
+        // CONFIRMED 여부 확인
+        boolean wasConfirmed = enrollment.getStatus() == EnrollmentStatus.CONFIRMED;
+
+        // 강의 조회
+        ClassEntity classEntity = classRepository.findByIdForUpdate(enrollment.getClassEntity().getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 수강 신청 취소
+        enrollment.cancel();
+
+        // 강의 수강생 수 감소
+        classEntity.decrementEnrolled();
+
+        // 환불 이력 저장
+        if (wasConfirmed) {
+            paymentRepository.save(Payment.refunded(enrollment, classEntity.getPrice()));
+        }
+
+        return EnrollmentResponse.from(enrollment);
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -5,6 +5,7 @@ import com.enrollment.domain.classes.entity.ClassStatus;
 import com.enrollment.domain.classes.repository.ClassRepository;
 import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
 import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.dto.EnrollmentWithUserResponse;
 import com.enrollment.domain.enrollment.entity.Enrollment;
 import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
 import com.enrollment.domain.payment.entity.Payment;
@@ -15,6 +16,8 @@ import com.enrollment.domain.user.repository.UserRepository;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -120,5 +123,31 @@ public class EnrollmentService {
         }
 
         return EnrollmentResponse.from(enrollment);
+    }
+
+    // 내 수강 신청 목록 조회
+    public Page<EnrollmentResponse> getMyEnrollments(Long userId, Pageable pageable) {
+
+        // 사용자 존재 여부 검증
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        return enrollmentRepository.findByUserId(userId, pageable)
+                .map(EnrollmentResponse::from);
+    }
+
+    // 강의별 수강생 목록 조회 (강사 전용)
+    public Page<EnrollmentWithUserResponse> getClassEnrollments(Long userId, Long classId, Pageable pageable) {
+
+        // 강의 조회
+        ClassEntity classEntity = classRepository.findWithCreatorById(classId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 강의 소유자 검증
+        classEntity.validateOwner(userId);
+
+        return enrollmentRepository.findByClassEntityId(classId, pageable)
+                .map(EnrollmentWithUserResponse::from);
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/Payment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/Payment.java
@@ -1,0 +1,68 @@
+package com.enrollment.domain.payment.entity;
+
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "enrollment_id", nullable = false)
+    private Enrollment enrollment;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentStatus status;
+
+    @Column(name = "paid_at", nullable = false)
+    private LocalDateTime paidAt;
+
+    public static Payment paid(Enrollment enrollment, Integer amount) {
+        return Payment.builder()
+                .enrollment(enrollment)
+                .amount(amount)
+                .status(PaymentStatus.PAID)
+                .paidAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Payment refunded(Enrollment enrollment, Integer amount) {
+        return Payment.builder()
+                .enrollment(enrollment)
+                .amount(amount)
+                .status(PaymentStatus.REFUNDED)
+                .paidAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/PaymentStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.enrollment.domain.payment.entity;
+
+public enum PaymentStatus {
+    PAID, REFUNDED, FAILED
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/payment/repository/PaymentRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.enrollment.domain.payment.repository;
+
+import com.enrollment.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "권한이 없습니다"),
     NOT_COURSE_OWNER(HttpStatus.FORBIDDEN, "NOT_COURSE_OWNER", "해당 강의의 소유자가 아닙니다"),
+    NOT_ENROLLMENT_OWNER(HttpStatus.FORBIDDEN, "NOT_ENROLLMENT_OWNER", "본인의 수강 신청만 수정할 수 있습니다"),
     FORBIDDEN_ROLE(HttpStatus.FORBIDDEN, "FORBIDDEN_ROLE", "해당 역할은 이 작업을 수행할 수 없습니다"),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다"),

--- a/enrollment-api/src/main/resources/db/migration/V4__create_enrollments_table.sql
+++ b/enrollment-api/src/main/resources/db/migration/V4__create_enrollments_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE enrollments (
+    enrollment_id  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    class_id       BIGINT NOT NULL REFERENCES classes(class_id),
+    user_id        BIGINT NOT NULL REFERENCES users(user_id),
+    status         VARCHAR(20) NOT NULL,
+    enrolled_at    TIMESTAMP(6) NOT NULL,
+    confirmed_at   TIMESTAMP(6),
+    cancelled_at   TIMESTAMP(6),
+    created_at     TIMESTAMP(6) NOT NULL,
+    updated_at     TIMESTAMP(6) NOT NULL,
+    CONSTRAINT chk_enrollment_status CHECK (status IN ('PENDING', 'CONFIRMED', 'CANCELLED'))
+);
+
+CREATE INDEX idx_enrollments_user_id ON enrollments(user_id);
+CREATE INDEX idx_enrollments_class_id ON enrollments(class_id);
+CREATE UNIQUE INDEX uk_active_enrollment ON enrollments(class_id, user_id)
+    WHERE status IN ('PENDING', 'CONFIRMED');

--- a/enrollment-api/src/main/resources/db/migration/V5__create_payments_table.sql
+++ b/enrollment-api/src/main/resources/db/migration/V5__create_payments_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE payments (
+    payment_id     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    enrollment_id  BIGINT NOT NULL REFERENCES enrollments(enrollment_id),
+    amount         INTEGER NOT NULL,
+    status         VARCHAR(20) NOT NULL,
+    paid_at        TIMESTAMP(6) NOT NULL,
+    created_at     TIMESTAMP(6) NOT NULL,
+    updated_at     TIMESTAMP(6) NOT NULL,
+    CONSTRAINT chk_payment_amount CHECK (amount >= 0),
+    CONSTRAINT chk_payment_status CHECK (status IN ('PAID', 'REFUNDED', 'FAILED'))
+);
+
+CREATE INDEX idx_payments_enrollment_id ON payments(enrollment_id);
+CREATE UNIQUE INDEX uk_payment_paid ON payments(enrollment_id) WHERE status = 'PAID';

--- a/enrollment-api/src/test/java/com/enrollment/domain/classes/controller/ClassControllerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/classes/controller/ClassControllerTest.java
@@ -3,6 +3,8 @@ package com.enrollment.domain.classes.controller;
 import com.enrollment.domain.classes.dto.ClassResponse;
 import com.enrollment.domain.classes.entity.ClassStatus;
 import com.enrollment.domain.classes.service.ClassService;
+import com.enrollment.domain.enrollment.dto.EnrollmentWithUserResponse;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
 import com.enrollment.global.error.GlobalExceptionHandler;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
@@ -38,6 +40,8 @@ class ClassControllerTest {
     ObjectMapper objectMapper;
     @MockBean
     ClassService classService;
+    @MockBean
+    EnrollmentService enrollmentService;
 
     private static final LocalDateTime NOW = LocalDateTime.of(2025, 1, 1, 0, 0);
 
@@ -444,6 +448,48 @@ class ClassControllerTest {
                             .param("size", "20"))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+        }
+    }
+
+    @Nested
+    class GetClassEnrollments {
+
+        @Test
+        void 강사_본인_강의_수강생_목록_200() throws Exception {
+            EnrollmentWithUserResponse response = new EnrollmentWithUserResponse(
+                    100L, 2L, "student", "PENDING", NOW);
+            given(enrollmentService.getClassEnrollments(eq(1L), eq(1L), any()))
+                    .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+            mockMvc.perform(get("/classes/1/enrollments")
+                            .header("X-User-Id", 1L)
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].enrollmentId").value(100))
+                    .andExpect(jsonPath("$.content[0].userName").value("student"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            given(enrollmentService.getClassEnrollments(eq(999L), eq(1L), any()))
+                    .willThrow(new BusinessException(ErrorCode.NOT_COURSE_OWNER));
+
+            mockMvc.perform(get("/classes/1/enrollments")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_COURSE_OWNER"));
+        }
+
+        @Test
+        void 강의_미존재_시_404() throws Exception {
+            given(enrollmentService.getClassEnrollments(eq(1L), eq(999L), any()))
+                    .willThrow(new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+            mockMvc.perform(get("/classes/999/enrollments")
+                            .header("X-User-Id", 1L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
         }
     }
 }

--- a/enrollment-api/src/test/java/com/enrollment/domain/classes/entity/ClassEntityTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/classes/entity/ClassEntityTest.java
@@ -244,6 +244,71 @@ class ClassEntityTest {
         }
     }
 
+    @Nested
+    class IncrementEnrolled {
+
+        @Test
+        void 정상_증가() {
+            ClassEntity entity = validDraft();
+            entity.incrementEnrolled();
+            assertThat(entity.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 정원_도달_시_CAPACITY_EXCEEDED_예외() {
+            ClassEntity entity = ClassEntity.builder()
+                    .createdBy(owner)
+                    .title("Java 기초").description("설명")
+                    .price(10000).capacity(2).enrolledCount(2)
+                    .startDate(LocalDate.of(2025, 3, 1))
+                    .endDate(LocalDate.of(2025, 6, 30))
+                    .status(ClassStatus.OPEN).build();
+            assertThatThrownBy(entity::incrementEnrolled)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CAPACITY_EXCEEDED));
+        }
+
+        @Test
+        void 정원_마지막_자리까지_증가_가능() {
+            ClassEntity entity = ClassEntity.builder()
+                    .createdBy(owner)
+                    .title("Java 기초").description("설명")
+                    .price(10000).capacity(2).enrolledCount(1)
+                    .startDate(LocalDate.of(2025, 3, 1))
+                    .endDate(LocalDate.of(2025, 6, 30))
+                    .status(ClassStatus.OPEN).build();
+            entity.incrementEnrolled();
+            assertThat(entity.getEnrolledCount()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class DecrementEnrolled {
+
+        @Test
+        void 정상_감소() {
+            ClassEntity entity = ClassEntity.builder()
+                    .createdBy(owner)
+                    .title("Java 기초").description("설명")
+                    .price(10000).capacity(30).enrolledCount(5)
+                    .startDate(LocalDate.of(2025, 3, 1))
+                    .endDate(LocalDate.of(2025, 6, 30))
+                    .status(ClassStatus.OPEN).build();
+            entity.decrementEnrolled();
+            assertThat(entity.getEnrolledCount()).isEqualTo(4);
+        }
+
+        @Test
+        void enrolledCount_0일_때_감소_시_INVALID_INPUT_예외() {
+            ClassEntity entity = validDraft();
+            assertThatThrownBy(entity::decrementEnrolled)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+    }
+
     private void setId(Object obj, Long id) throws Exception {
         Field field = obj.getClass().getDeclaredField("id");
         field.setAccessible(true);

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/EnrollmentConcurrencyTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/EnrollmentConcurrencyTest.java
@@ -1,0 +1,112 @@
+package com.enrollment.domain.enrollment;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class EnrollmentConcurrencyTest extends AbstractIntegrationTest {
+
+    @Autowired
+    EnrollmentService enrollmentService;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    EnrollmentRepository enrollmentRepository;
+
+    private Long classId;
+    private List<Long> classmateIds;
+
+    @BeforeEach
+    void setUp() {
+        User creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build());
+
+        // 10명의 학생이 동시에 같은 강의에 신청 — 중복 방지 인덱스 우회를 위해 유저는 서로 다름
+        classmateIds = IntStream.range(0, 10)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("학생" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("마감_임박_강의").description("정원 1석")
+                        .price(10000).capacity(1).enrolledCount(0)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+
+        classId = openClass.getId();
+    }
+
+    @Test
+    void 정원_1명_강의에_10명이_동시_신청_시_정확히_1명만_성공() throws Exception {
+        int threadCount = classmateIds.size();
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+        for (Long classmateId : classmateIds) {
+            pool.submit(() -> {
+                try {
+                    startLatch.await();
+                    enrollmentService.enroll(classmateId, new EnrollmentCreateRequest(classId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    // BusinessException(CAPACITY_EXCEEDED) + 락/트랜잭션 예외 모두 실패로 집계
+                    failCount.incrementAndGet();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        boolean finished = doneLatch.await(15, TimeUnit.SECONDS);
+        pool.shutdown();
+
+        assertThat(finished).isTrue();
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(threadCount - 1);
+
+        ClassEntity finalClass = classRepository.findById(classId).orElseThrow();
+        assertThat(finalClass.getEnrolledCount()).isEqualTo(1);
+
+        long activeEnrollments = enrollmentRepository.findByClassEntityId(classId, PageRequest.of(0, 20))
+                .stream()
+                .filter(e -> e.getStatus() != EnrollmentStatus.CANCELLED)
+                .count();
+        assertThat(activeEnrollments).isEqualTo(1);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/controller/EnrollmentControllerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/controller/EnrollmentControllerTest.java
@@ -1,0 +1,242 @@
+package com.enrollment.domain.enrollment.controller;
+
+import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.global.error.GlobalExceptionHandler;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(EnrollmentController.class)
+@Import(GlobalExceptionHandler.class)
+class EnrollmentControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @MockBean
+    EnrollmentService enrollmentService;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 1, 1, 0, 0);
+
+    private EnrollmentResponse sampleResponse(String status) {
+        return new EnrollmentResponse(100L, 10L, "Java 기초", status, NOW, null, null);
+    }
+
+    @Nested
+    class Enroll {
+
+        @Test
+        void 정상_신청_201() throws Exception {
+            given(enrollmentService.enroll(eq(2L), any())).willReturn(sampleResponse("PENDING"));
+
+            String body = """
+                    {"classId": 10}
+                    """;
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.enrollmentId").value(100))
+                    .andExpect(jsonPath("$.classId").value(10))
+                    .andExpect(jsonPath("$.status").value("PENDING"));
+        }
+
+        @Test
+        void classId_누락_시_400() throws Exception {
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+
+        @Test
+        void 강의_미존재_시_404() throws Exception {
+            given(enrollmentService.enroll(eq(2L), any()))
+                    .willThrow(new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"classId\": 999}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
+        }
+
+        @Test
+        void 사용자_미존재_시_404() throws Exception {
+            given(enrollmentService.enroll(eq(999L), any()))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 999L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"classId\": 10}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+        }
+
+        @Test
+        void 정원_초과_시_400() throws Exception {
+            given(enrollmentService.enroll(eq(2L), any()))
+                    .willThrow(new BusinessException(ErrorCode.CAPACITY_EXCEEDED));
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"classId\": 10}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("CAPACITY_EXCEEDED"));
+        }
+
+        @Test
+        void 이미_신청한_강의면_409() throws Exception {
+            given(enrollmentService.enroll(eq(2L), any()))
+                    .willThrow(new BusinessException(ErrorCode.ALREADY_ENROLLED));
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"classId\": 10}"))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("ALREADY_ENROLLED"));
+        }
+    }
+
+    @Nested
+    class Pay {
+
+        @Test
+        void 정상_결제_200() throws Exception {
+            given(enrollmentService.pay(2L, 100L)).willReturn(sampleResponse("CONFIRMED"));
+
+            mockMvc.perform(patch("/enrollments/100/pay")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("CONFIRMED"));
+        }
+
+        @Test
+        void 신청_미존재_시_404() throws Exception {
+            given(enrollmentService.pay(2L, 999L))
+                    .willThrow(new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
+
+            mockMvc.perform(patch("/enrollments/999/pay")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("ENROLLMENT_NOT_FOUND"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            given(enrollmentService.pay(999L, 100L))
+                    .willThrow(new BusinessException(ErrorCode.NOT_ENROLLMENT_OWNER));
+
+            mockMvc.perform(patch("/enrollments/100/pay")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_ENROLLMENT_OWNER"));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void 정상_취소_200() throws Exception {
+            given(enrollmentService.cancel(2L, 100L)).willReturn(sampleResponse("CANCELLED"));
+
+            mockMvc.perform(patch("/enrollments/100/cancel")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("CANCELLED"));
+        }
+
+        @Test
+        void 취소_기간_초과_시_400() throws Exception {
+            given(enrollmentService.cancel(2L, 100L))
+                    .willThrow(new BusinessException(ErrorCode.CANCEL_PERIOD_EXPIRED));
+
+            mockMvc.perform(patch("/enrollments/100/cancel")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("CANCEL_PERIOD_EXPIRED"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            given(enrollmentService.cancel(999L, 100L))
+                    .willThrow(new BusinessException(ErrorCode.NOT_ENROLLMENT_OWNER));
+
+            mockMvc.perform(patch("/enrollments/100/cancel")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_ENROLLMENT_OWNER"));
+        }
+
+        @Test
+        void 이미_취소된_신청이면_400() throws Exception {
+            given(enrollmentService.cancel(2L, 100L))
+                    .willThrow(new BusinessException(ErrorCode.ALREADY_CANCELLED));
+
+            mockMvc.perform(patch("/enrollments/100/cancel")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("ALREADY_CANCELLED"));
+        }
+    }
+
+    @Nested
+    class GetMyEnrollments {
+
+        @Test
+        void 내_신청_목록_200() throws Exception {
+            given(enrollmentService.getMyEnrollments(eq(2L), any()))
+                    .willReturn(new PageImpl<>(List.of(sampleResponse("PENDING")),
+                            PageRequest.of(0, 20), 1));
+
+            mockMvc.perform(get("/enrollments/me")
+                            .header("X-User-Id", 2L)
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].enrollmentId").value(100))
+                    .andExpect(jsonPath("$.totalElements").value(1));
+        }
+
+        @Test
+        void 사용자_미존재_시_404() throws Exception {
+            given(enrollmentService.getMyEnrollments(eq(999L), any()))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            mockMvc.perform(get("/enrollments/me")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+        }
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentStatusTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentStatusTest.java
@@ -1,0 +1,41 @@
+package com.enrollment.domain.enrollment.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnrollmentStatusTest {
+
+    @Test
+    void PENDING에서_CONFIRMED로_전이_가능() {
+        assertThat(EnrollmentStatus.PENDING.canTransitionTo(EnrollmentStatus.CONFIRMED)).isTrue();
+    }
+
+    @Test
+    void PENDING에서_CANCELLED로_전이_가능() {
+        assertThat(EnrollmentStatus.PENDING.canTransitionTo(EnrollmentStatus.CANCELLED)).isTrue();
+    }
+
+    @Test
+    void CONFIRMED에서_CANCELLED로_전이_가능() {
+        assertThat(EnrollmentStatus.CONFIRMED.canTransitionTo(EnrollmentStatus.CANCELLED)).isTrue();
+    }
+
+    @Test
+    void CONFIRMED에서_PENDING으로_전이_불가() {
+        assertThat(EnrollmentStatus.CONFIRMED.canTransitionTo(EnrollmentStatus.PENDING)).isFalse();
+    }
+
+    @Test
+    void CANCELLED에서_어디로도_전이_불가() {
+        assertThat(EnrollmentStatus.CANCELLED.canTransitionTo(EnrollmentStatus.PENDING)).isFalse();
+        assertThat(EnrollmentStatus.CANCELLED.canTransitionTo(EnrollmentStatus.CONFIRMED)).isFalse();
+    }
+
+    @Test
+    void 같은_상태로_전이_불가() {
+        assertThat(EnrollmentStatus.PENDING.canTransitionTo(EnrollmentStatus.PENDING)).isFalse();
+        assertThat(EnrollmentStatus.CONFIRMED.canTransitionTo(EnrollmentStatus.CONFIRMED)).isFalse();
+        assertThat(EnrollmentStatus.CANCELLED.canTransitionTo(EnrollmentStatus.CANCELLED)).isFalse();
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentTest.java
@@ -1,0 +1,206 @@
+package com.enrollment.domain.enrollment.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EnrollmentTest {
+
+    private User classmate;
+    private ClassEntity openClass;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+
+        classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+
+        openClass = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초")
+                .description("설명")
+                .price(10000)
+                .capacity(30)
+                .enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT)
+                .build();
+        setId(openClass, 10L);
+        openClass.publish();
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void create_시_PENDING_상태와_enrolledAt_설정() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+            assertThat(enrollment.getEnrolledAt()).isNotNull();
+            assertThat(enrollment.getConfirmedAt()).isNull();
+            assertThat(enrollment.getCancelledAt()).isNull();
+            assertThat(enrollment.getClassEntity()).isEqualTo(openClass);
+            assertThat(enrollment.getUser()).isEqualTo(classmate);
+        }
+    }
+
+    @Nested
+    class Confirm {
+
+        @Test
+        void PENDING에서_confirm_성공() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+            assertThat(enrollment.getConfirmedAt()).isNotNull();
+        }
+
+        @Test
+        void CONFIRMED에서_confirm_시_INVALID_STATE_TRANSITION() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            assertThatThrownBy(enrollment::confirm)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void CANCELLED에서_confirm_시_INVALID_STATE_TRANSITION() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.cancel();
+            assertThatThrownBy(enrollment::confirm)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void PENDING에서_cancel_성공() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.cancel();
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+            assertThat(enrollment.getCancelledAt()).isNotNull();
+        }
+
+        @Test
+        void CONFIRMED_7일_이내_cancel_성공() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            // confirmedAt을 6일 전으로 설정
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(6));
+
+            enrollment.cancel();
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+            assertThat(enrollment.getCancelledAt()).isNotNull();
+        }
+
+        @Test
+        void CONFIRMED_7일_초과_cancel_시_CANCEL_PERIOD_EXPIRED() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            // confirmedAt을 8일 전으로 설정
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(8));
+
+            assertThatThrownBy(enrollment::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CANCEL_PERIOD_EXPIRED));
+        }
+
+        @Test
+        void CONFIRMED_정확히_7일째_cancel_허용() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            // 7일 경계 바로 안쪽 → plusDays(7).isBefore(now) == false → 허용
+            // (테스트 실행 중 now()가 아주 미세하게 진행되므로 5초 버퍼 부여)
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(7).plusSeconds(5));
+
+            enrollment.cancel();
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        }
+
+        @Test
+        void CONFIRMED_7일_1초_후_cancel_실패() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            // 7일 + 1초 경과 → CANCEL_PERIOD_EXPIRED
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(7).minusSeconds(1));
+
+            assertThatThrownBy(enrollment::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CANCEL_PERIOD_EXPIRED));
+        }
+
+        @Test
+        void CANCELLED에서_cancel_시_ALREADY_CANCELLED() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.cancel();
+            assertThatThrownBy(enrollment::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_CANCELLED));
+        }
+    }
+
+    @Nested
+    class ValidateOwner {
+
+        @Test
+        void 소유자_일치_시_예외_없음() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.validateOwner(2L);
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_ENROLLMENT_OWNER_예외() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            assertThatThrownBy(() -> enrollment.validateOwner(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_ENROLLMENT_OWNER));
+        }
+    }
+
+    private Enrollment newEnrollment(ClassEntity classEntity, User user) {
+        return Enrollment.builder()
+                .classEntity(classEntity)
+                .user(user)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .build();
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+
+    private void setField(Object obj, String name, Object value) throws Exception {
+        Field field = obj.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/repository/EnrollmentRepositoryTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/repository/EnrollmentRepositoryTest.java
@@ -1,0 +1,168 @@
+package com.enrollment.domain.enrollment.repository;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.config.JpaAuditingConfig;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Import(JpaAuditingConfig.class)
+class EnrollmentRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    TestEntityManager em;
+    @Autowired
+    EnrollmentRepository enrollmentRepository;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+
+    private User creator;
+    private User classmate;
+    private ClassEntity openClass;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build()
+        );
+        classmate = userRepository.saveAndFlush(
+                User.builder().name("student").role(UserRole.CLASSMATE).build()
+        );
+        openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("Java 기초").description("설명")
+                        .price(10000).capacity(30).enrolledCount(0)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build()
+        );
+    }
+
+    @Test
+    void save_시_id_자동_생성_및_auditing() {
+        Enrollment saved = enrollmentRepository.saveAndFlush(
+                newEnrollment(openClass, classmate));
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+        assertThat(saved.getEnrolledAt()).isNotNull();
+    }
+
+    @Test
+    void findByIdForUpdate_JOIN_FETCH로_classEntity와_user_즉시_로딩() {
+        Long id = enrollmentRepository.saveAndFlush(
+                newEnrollment(openClass, classmate)).getId();
+        em.clear();
+
+        Optional<Enrollment> found = enrollmentRepository.findByIdForUpdate(id);
+        assertThat(found).isPresent();
+        // LazyInitializationException 없이 접근 가능해야 함
+        assertThat(found.get().getClassEntity().getTitle()).isEqualTo("Java 기초");
+        assertThat(found.get().getUser().getName()).isEqualTo("student");
+    }
+
+    @Test
+    void findByUserId_페이지네이션_성공() {
+        enrollmentRepository.saveAndFlush(newEnrollment(openClass, classmate));
+        em.clear();
+
+        Page<Enrollment> result = enrollmentRepository.findByUserId(
+                classmate.getId(), PageRequest.of(0, 10));
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        // EntityGraph must load classEntity eagerly
+        assertThat(result.getContent().get(0).getClassEntity().getTitle()).isEqualTo("Java 기초");
+    }
+
+    @Test
+    void findByClassEntityId_페이지네이션_성공() {
+        enrollmentRepository.saveAndFlush(newEnrollment(openClass, classmate));
+        em.clear();
+
+        Page<Enrollment> result = enrollmentRepository.findByClassEntityId(
+                openClass.getId(), PageRequest.of(0, 10));
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        // EntityGraph must load user eagerly
+        assertThat(result.getContent().get(0).getUser().getName()).isEqualTo("student");
+    }
+
+    @Test
+    void existsByClassIdAndUserIdAndStatusIn_중복_체크() {
+        enrollmentRepository.saveAndFlush(newEnrollment(openClass, classmate));
+        em.clear();
+
+        boolean exists = enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                openClass.getId(), classmate.getId(),
+                List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED));
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void existsByClassIdAndUserIdAndStatusIn_미존재시_false() {
+        boolean exists = enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                openClass.getId(), classmate.getId(),
+                List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED));
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    void 부분_유니크_인덱스_활성_상태_중복_방지() {
+        enrollmentRepository.saveAndFlush(newEnrollment(openClass, classmate));
+        em.clear();
+
+        Enrollment duplicate = newEnrollment(openClass, classmate);
+        assertThatThrownBy(() -> enrollmentRepository.saveAndFlush(duplicate))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 부분_유니크_인덱스_CANCELLED_후_재신청_허용() {
+        Enrollment first = enrollmentRepository.saveAndFlush(
+                newEnrollment(openClass, classmate));
+        first.cancel();
+        enrollmentRepository.saveAndFlush(first);
+        em.clear();
+
+        Enrollment secondAttempt = newEnrollment(openClass, classmate);
+        Enrollment saved = enrollmentRepository.saveAndFlush(secondAttempt);
+        assertThat(saved.getId()).isNotNull();
+    }
+
+    private Enrollment newEnrollment(ClassEntity classEntity, User user) {
+        return Enrollment.builder()
+                .classEntity(classEntity)
+                .user(user)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
@@ -1,0 +1,428 @@
+package com.enrollment.domain.enrollment.service;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
+import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.dto.EnrollmentWithUserResponse;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.payment.entity.Payment;
+import com.enrollment.domain.payment.entity.PaymentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.payment.repository.PaymentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentServiceTest {
+
+    @Mock
+    EnrollmentRepository enrollmentRepository;
+    @Mock
+    PaymentRepository paymentRepository;
+    @Mock
+    ClassRepository classRepository;
+    @Mock
+    UserRepository userRepository;
+    @InjectMocks
+    EnrollmentService enrollmentService;
+
+    private User creator;
+    private User classmate;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+        classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+    }
+
+    private ClassEntity openClass(int capacity, int enrolled) throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(capacity).enrolledCount(enrolled)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        entity.publish();
+        return entity;
+    }
+
+    private ClassEntity draftClass() throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(30).enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        return entity;
+    }
+
+    private Enrollment pendingEnrollment(ClassEntity classEntity) throws Exception {
+        Enrollment enrollment = Enrollment.builder()
+                .classEntity(classEntity)
+                .user(classmate)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .build();
+        setId(enrollment, 100L);
+        return enrollment;
+    }
+
+    @Nested
+    class Enroll {
+
+        @Test
+        void 정상_신청() throws Exception {
+            ClassEntity openClass = openClass(30, 0);
+            EnrollmentCreateRequest request = new EnrollmentCreateRequest(10L);
+
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+            given(enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                    eq(10L), eq(2L), anyCollection())).willReturn(false);
+            given(enrollmentRepository.save(any(Enrollment.class))).willAnswer(inv -> {
+                Enrollment e = inv.getArgument(0);
+                try { setId(e, 100L); } catch (Exception ignored) {}
+                return e;
+            });
+
+            EnrollmentResponse response = enrollmentService.enroll(2L, request);
+
+            assertThat(response.enrollmentId()).isEqualTo(100L);
+            assertThat(response.classId()).isEqualTo(10L);
+            assertThat(response.status()).isEqualTo("PENDING");
+            assertThat(openClass.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 사용자_미존재_시_USER_NOT_FOUND() {
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.enroll(999L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+
+        @Test
+        void 강의_미존재_시_CLASS_NOT_FOUND() {
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.enroll(2L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CLASS_NOT_FOUND));
+        }
+
+        @Test
+        void 강의가_OPEN이_아니면_INVALID_STATE_TRANSITION() throws Exception {
+            ClassEntity draft = draftClass();
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(draft));
+
+            assertThatThrownBy(() -> enrollmentService.enroll(2L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void 이미_신청한_강의면_ALREADY_ENROLLED() throws Exception {
+            ClassEntity openClass = openClass(30, 0);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+            given(enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                    eq(10L), eq(2L), anyCollection())).willReturn(true);
+
+            assertThatThrownBy(() -> enrollmentService.enroll(2L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_ENROLLED));
+        }
+
+        @Test
+        void 정원_초과_시_CAPACITY_EXCEEDED() throws Exception {
+            ClassEntity fullClass = openClass(2, 2);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(fullClass));
+            given(enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                    eq(10L), eq(2L), anyCollection())).willReturn(false);
+
+            assertThatThrownBy(() -> enrollmentService.enroll(2L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CAPACITY_EXCEEDED));
+            verify(enrollmentRepository, never()).save(any(Enrollment.class));
+        }
+    }
+
+    @Nested
+    class Pay {
+
+        @Test
+        void 정상_결제() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+
+            ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+            given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+            EnrollmentResponse response = enrollmentService.pay(2L, 100L);
+
+            assertThat(response.status()).isEqualTo("CONFIRMED");
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+
+            verify(paymentRepository).save(paymentCaptor.capture());
+            Payment saved = paymentCaptor.getValue();
+            assertThat(saved.getStatus()).isEqualTo(PaymentStatus.PAID);
+            assertThat(saved.getAmount()).isEqualTo(10000);
+        }
+
+        @Test
+        void 신청_미존재_시_ENROLLMENT_NOT_FOUND() {
+            given(enrollmentRepository.findWithClassAndUserById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.pay(2L, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ENROLLMENT_NOT_FOUND));
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_ENROLLMENT_OWNER() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+
+            assertThatThrownBy(() -> enrollmentService.pay(999L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_ENROLLMENT_OWNER));
+        }
+
+        @Test
+        void CONFIRMED_상태에서_재결제_시_INVALID_STATE_TRANSITION() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            enrollment.confirm();
+            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+
+            assertThatThrownBy(() -> enrollmentService.pay(2L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void PENDING_취소_환불없음() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+
+            EnrollmentResponse response = enrollmentService.cancel(2L, 100L);
+
+            assertThat(response.status()).isEqualTo("CANCELLED");
+            assertThat(openClass.getEnrolledCount()).isEqualTo(0);
+            verify(paymentRepository, never()).save(any(Payment.class));
+        }
+
+        @Test
+        void CONFIRMED_7일_이내_취소_환불_발생() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            enrollment.confirm();
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(3));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+            given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+            EnrollmentResponse response = enrollmentService.cancel(2L, 100L);
+
+            assertThat(response.status()).isEqualTo("CANCELLED");
+            assertThat(openClass.getEnrolledCount()).isEqualTo(0);
+
+            ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+            verify(paymentRepository).save(captor.capture());
+            assertThat(captor.getValue().getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        }
+
+        @Test
+        void CONFIRMED_7일_초과_시_CANCEL_PERIOD_EXPIRED() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            enrollment.confirm();
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(8));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+
+            assertThatThrownBy(() -> enrollmentService.cancel(2L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CANCEL_PERIOD_EXPIRED));
+            verify(paymentRepository, never()).save(any(Payment.class));
+            assertThat(openClass.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_ENROLLMENT_OWNER() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+
+            assertThatThrownBy(() -> enrollmentService.cancel(999L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_ENROLLMENT_OWNER));
+        }
+
+        @Test
+        void 신청_미존재_시_ENROLLMENT_NOT_FOUND() {
+            given(enrollmentRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.cancel(2L, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ENROLLMENT_NOT_FOUND));
+        }
+
+        @Test
+        void 이미_취소된_신청이면_ALREADY_CANCELLED() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            enrollment.cancel();
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+
+            assertThatThrownBy(() -> enrollmentService.cancel(2L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_CANCELLED));
+        }
+    }
+
+    @Nested
+    class GetMyEnrollments {
+
+        @Test
+        void 내_신청_목록_조회_성공() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            Page<Enrollment> page = new PageImpl<>(List.of(enrollment));
+            Pageable pageable = PageRequest.of(0, 20);
+
+            given(userRepository.existsById(2L)).willReturn(true);
+            given(enrollmentRepository.findByUserId(2L, pageable)).willReturn(page);
+
+            Page<EnrollmentResponse> result = enrollmentService.getMyEnrollments(2L, pageable);
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).classId()).isEqualTo(10L);
+        }
+
+        @Test
+        void 사용자_미존재_시_USER_NOT_FOUND() {
+            given(userRepository.existsById(999L)).willReturn(false);
+
+            assertThatThrownBy(() -> enrollmentService.getMyEnrollments(999L, PageRequest.of(0, 20)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    class GetClassEnrollments {
+
+        @Test
+        void 강사_본인_강의_수강생_목록_조회_성공() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            Page<Enrollment> page = new PageImpl<>(List.of(enrollment));
+            Pageable pageable = PageRequest.of(0, 20);
+
+            given(classRepository.findWithCreatorById(10L)).willReturn(Optional.of(openClass));
+            given(enrollmentRepository.findByClassEntityId(10L, pageable)).willReturn(page);
+
+            Page<EnrollmentWithUserResponse> result = enrollmentService.getClassEnrollments(1L, 10L, pageable);
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).userName()).isEqualTo("student");
+        }
+
+        @Test
+        void 강의_미존재_시_CLASS_NOT_FOUND() {
+            given(classRepository.findWithCreatorById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.getClassEnrollments(1L, 999L, PageRequest.of(0, 20)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CLASS_NOT_FOUND));
+        }
+
+        @Test
+        void 강사_소유자_아니면_NOT_COURSE_OWNER() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            given(classRepository.findWithCreatorById(10L)).willReturn(Optional.of(openClass));
+
+            assertThatThrownBy(() -> enrollmentService.getClassEnrollments(999L, 10L, PageRequest.of(0, 20)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_COURSE_OWNER));
+        }
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+
+    private void setField(Object obj, String name, Object value) throws Exception {
+        Field field = obj.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/payment/entity/PaymentTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/payment/entity/PaymentTest.java
@@ -1,0 +1,75 @@
+package com.enrollment.domain.payment.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PaymentTest {
+
+    private Enrollment enrollment;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+
+        User classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+
+        ClassEntity openClass = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초")
+                .description("설명")
+                .price(10000)
+                .capacity(30)
+                .enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT)
+                .build();
+        setId(openClass, 10L);
+        openClass.publish();
+
+        enrollment = Enrollment.builder()
+                .classEntity(openClass)
+                .user(classmate)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    void paid_팩토리_메서드_PAID_상태_생성() {
+        Payment payment = Payment.paid(enrollment, 10000);
+        assertThat(payment.getEnrollment()).isEqualTo(enrollment);
+        assertThat(payment.getAmount()).isEqualTo(10000);
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+        assertThat(payment.getPaidAt()).isNotNull();
+    }
+
+    @Test
+    void refunded_팩토리_메서드_REFUNDED_상태_생성() {
+        Payment payment = Payment.refunded(enrollment, 10000);
+        assertThat(payment.getEnrollment()).isEqualTo(enrollment);
+        assertThat(payment.getAmount()).isEqualTo(10000);
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        assertThat(payment.getPaidAt()).isNotNull();
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.*;
 
 import com.enrollment.domain.classes.service.ClassService;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -30,6 +31,8 @@ class GlobalExceptionHandlerTest {
     MockMvc mockMvc;
     @MockBean
     ClassService classService;
+    @MockBean
+    EnrollmentService enrollmentService;
 
     @Test
     void BusinessException_시_ErrorCode의_HttpStatus와_포맷으로_응답() throws Exception {


### PR DESCRIPTION
## Summary
- 수강 신청/결제/취소/조회 5개 API (상태 머신 PENDING → CONFIRMED → CANCELLED)
- 좌석 홀드 방식 정원 관리, 비관적 락 기반 동시성 제어
- 결제는 호출 즉시 PAID 상태 기록 (외부 PG 연동 없음)
- 수강 취소 기간 제한(CONFIRMED 이후 7일), 환불 이력 기록
- 강의별 수강생 목록 조회(강사 전용) 엔드포인트 추가

close #14

## 변경 사항

| 영역 | 파일 | 설명 |
|------|------|------|
| Domain | `Enrollment`, `EnrollmentStatus` | 상태 전이, 7일 취소 제한, 소유권 검증 도메인 메서드 |
| Domain | `Payment`, `PaymentStatus` | 이력 테이블, paid/refunded 정적 팩토리 |
| Domain | `ClassEntity` | `incrementEnrolled` / `decrementEnrolled` 추가 |
| Persistence | `EnrollmentRepository` | 비관적 락, EntityGraph, 페이징 |
| Persistence | `PaymentRepository` | 기본 CRUD |
| Persistence | `V4__create_enrollments_table.sql` | FK + CHECK + 부분 유니크 인덱스(중복 신청 방지) |
| Persistence | `V5__create_payments_table.sql` | FK + CHECK + PAID 부분 유니크 인덱스 |
| Service | `EnrollmentService` | 5개 비즈니스 로직(enroll/pay/cancel/getMyEnrollments/getClassEnrollments) |
| API | `EnrollmentController` | 4개 엔드포인트, X-User-Id 헤더 |
| API | `ClassController` | `GET /classes/{id}/enrollments` 추가 |
| Error | `ErrorCode.NOT_ENROLLMENT_OWNER` | 수강 신청 소유자 검증 |

## 테스트 결과
- [x] `./gradlew test` 통과
- [x] BUILD SUCCESSFUL
- 전체 160 tests, 0 failures
- `EnrollmentConcurrencyTest`: 정원 1명 강의에 10명 동시 신청 시 정확히 1명만 성공

## 영향 범위
- 신규 엔드포인트 5개: `POST /enrollments`, `PATCH /enrollments/{id}/pay`, `PATCH /enrollments/{id}/cancel`, `GET /enrollments/me`, `GET /classes/{id}/enrollments`
- `ClassEntity` 좌석 관리 도메인 메서드 추가(기존 API 영향 없음)
- `ErrorCode`에 `NOT_ENROLLMENT_OWNER` 추가
- Flyway V4, V5 마이그레이션 추가

## DB 마이그레이션

```sql
-- V4__create_enrollments_table.sql
CREATE TABLE enrollments (
    enrollment_id  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
    class_id       BIGINT NOT NULL REFERENCES classes(class_id),
    user_id        BIGINT NOT NULL REFERENCES users(user_id),
    status         VARCHAR(20) NOT NULL,
    enrolled_at    TIMESTAMP(6) NOT NULL,
    confirmed_at   TIMESTAMP(6),
    cancelled_at   TIMESTAMP(6),
    created_at     TIMESTAMP(6) NOT NULL,
    updated_at     TIMESTAMP(6) NOT NULL,
    CONSTRAINT chk_enrollment_status CHECK (status IN ('PENDING', 'CONFIRMED', 'CANCELLED'))
);
CREATE INDEX idx_enrollments_user_id ON enrollments(user_id);
CREATE INDEX idx_enrollments_class_id ON enrollments(class_id);
CREATE UNIQUE INDEX uk_active_enrollment ON enrollments(class_id, user_id)
    WHERE status IN ('PENDING', 'CONFIRMED');

-- V5__create_payments_table.sql
CREATE TABLE payments (
    payment_id     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
    enrollment_id  BIGINT NOT NULL REFERENCES enrollments(enrollment_id),
    amount         INTEGER NOT NULL,
    status         VARCHAR(20) NOT NULL,
    paid_at        TIMESTAMP(6) NOT NULL,
    created_at     TIMESTAMP(6) NOT NULL,
    updated_at     TIMESTAMP(6) NOT NULL,
    CONSTRAINT chk_payment_amount CHECK (amount >= 0),
    CONSTRAINT chk_payment_status CHECK (status IN ('PAID', 'REFUNDED', 'FAILED'))
);
CREATE INDEX idx_payments_enrollment_id ON payments(enrollment_id);
CREATE UNIQUE INDEX uk_payment_paid ON payments(enrollment_id) WHERE status = 'PAID';
```

## 리뷰어 테스트

```bash
# 1. DB + 앱 기동
cd enrollment-infra && docker compose up -d
cd ../enrollment-api && ./gradlew bootRun

# 2. Swagger UI
open http://localhost:8080/swagger-ui/index.html

# 3. 시나리오: 강의 등록 → 공개 → 수강 신청 → 결제 → 취소
# (시드 유저: user_id=1 CREATOR, user_id=2 CLASSMATE)

# 강의 등록
CLASS_ID=$(curl -s -X POST http://localhost:8080/classes \
  -H "X-User-Id: 1" -H "Content-Type: application/json" \
  -d '{"title":"Java 기초","price":50000,"capacity":10,"startDate":"2025-05-01","endDate":"2025-05-31"}' | jq -r .classId)

# 강의 공개
curl -s -X PATCH http://localhost:8080/classes/$CLASS_ID/publish -H "X-User-Id: 1" | jq

# 수강생 신청 (201 PENDING)
ENROLLMENT_ID=$(curl -s -X POST http://localhost:8080/enrollments \
  -H "X-User-Id: 2" -H "Content-Type: application/json" \
  -d "{\"classId\":$CLASS_ID}" | jq -r .enrollmentId)

# 결제 (200 CONFIRMED)
curl -s -X PATCH http://localhost:8080/enrollments/$ENROLLMENT_ID/pay -H "X-User-Id: 2" | jq

# 수강 취소 (200 CANCELLED)
curl -s -X PATCH http://localhost:8080/enrollments/$ENROLLMENT_ID/cancel -H "X-User-Id: 2" | jq

# 내 수강 신청 목록
curl -s "http://localhost:8080/enrollments/me" -H "X-User-Id: 2" | jq

# 강사용 수강생 목록
curl -s "http://localhost:8080/classes/$CLASS_ID/enrollments" -H "X-User-Id: 1" | jq
```
