### PR TITLE
[feat] 대기열(Waitlist) 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ HELP.md
 .omc
 
 todo.md
+기획서.md
+docs/

--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 온라인 라이브 클래스의 수강 신청 시스템 백엔드 API.
 
-> 과제 제출용 프로젝트
-
 ## 프로젝트 개요
 
-_(추후 작성)_
+크리에이터(강사)가 강의를 개설하고, 클래스메이트(수강생)가 신청·결제·취소하는 전 과정을 처리한다.
+
+**핵심 비즈니스 규칙**
+- 강의 상태 머신: `DRAFT → OPEN → CLOSED`
+- 수강 신청 상태 머신: `PENDING → CONFIRMED → CANCELLED`
+- 정원 초과 시 신청 거부, 동시 신청은 비관적 락으로 직렬화
+- CONFIRMED 이후 7일 이내에만 수강 취소 가능 (환불 이력 기록)
+- 정원이 찬 강의에는 대기열 등록 가능, 취소 발생 시 선두 자동 승격
 
 ## 기술 스택
 
@@ -17,14 +22,16 @@ _(추후 작성)_
 - Gradle
 - Docker / Docker Compose
 - Swagger UI (springdoc-openapi)
+- Testcontainers (JUnit 통합 테스트)
 
 ## 실행 방법
 
 ### 로컬
+
 ```bash
 # 1. DB 기동
 cd enrollment-infra
-docker-compose up -d
+docker compose up -d
 
 # 2. 앱 실행
 cd ../enrollment-api
@@ -38,30 +45,229 @@ curl http://localhost:8080/actuator/health
 open http://localhost:8080/swagger-ui/index.html
 ```
 
+### 시드 유저 (V3 마이그레이션)
+
+앱 기동 시 Flyway가 자동으로 시드 유저 2명을 생성한다.
+
+| user_id | role | 설명 |
+|---------|------|------|
+| 1 | CREATOR | 강사용 |
+| 2 | CLASSMATE | 수강생용 |
+
+`X-User-Id` 헤더로 식별하므로 리뷰 시 별도 가입 과정 없이 바로 API 호출 가능.
+
 ## API 목록 및 예시
 
-_(추후 작성)_
+### 강의 관리
+
+| # | Method | Path | 권한 |
+|---|--------|------|------|
+| 1 | POST | `/classes` | 강사 |
+| 2 | PATCH | `/classes/{id}` | 본인 강사 |
+| 3 | PATCH | `/classes/{id}/publish` | 본인 강사 |
+| 4 | PATCH | `/classes/{id}/close` | 본인 강사 |
+| 5 | GET | `/classes?status=OPEN&page=0&size=20` | 누구나 |
+| 6 | GET | `/classes/{id}` | 누구나 |
+| 7 | GET | `/classes/me?page=0&size=20` | 강사 |
+| 8 | GET | `/classes/{id}/enrollments?page=0&size=20` | 본인 강사 |
+
+### 수강 신청 / 결제 / 취소
+
+| # | Method | Path | 권한 |
+|---|--------|------|------|
+| 9 | POST | `/enrollments` | 수강생 |
+| 10 | PATCH | `/enrollments/{id}/pay` | 본인 수강생 |
+| 11 | PATCH | `/enrollments/{id}/cancel` | 본인 수강생 |
+| 12 | GET | `/enrollments/me?page=0&size=20` | 수강생 |
+
+### 대기열 (정원 초과 시)
+
+| # | Method | Path | 권한 |
+|---|--------|------|------|
+| 13 | POST | `/classes/{id}/waitlist` | 수강생 |
+| 14 | DELETE | `/classes/{id}/waitlist/me` | 본인 |
+
+### 요청 예시
+
+```bash
+# 강의 등록 (CREATOR)
+curl -X POST http://localhost:8080/classes \
+  -H "X-User-Id: 1" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Java 기초",
+    "description": "자바 입문 강의",
+    "price": 50000,
+    "capacity": 10,
+    "startDate": "2026-06-01",
+    "endDate": "2026-06-30"
+  }'
+
+# 강의 공개
+curl -X PATCH http://localhost:8080/classes/1/publish -H "X-User-Id: 1"
+
+# 수강 신청 (CLASSMATE)
+curl -X POST http://localhost:8080/enrollments \
+  -H "X-User-Id: 2" \
+  -H "Content-Type: application/json" \
+  -d '{"classId": 1}'
+
+# 결제
+curl -X PATCH http://localhost:8080/enrollments/1/pay -H "X-User-Id: 2"
+
+# 취소
+curl -X PATCH http://localhost:8080/enrollments/1/cancel -H "X-User-Id: 2"
+
+# 대기열 등록 (정원 초과 시)
+curl -X POST http://localhost:8080/classes/1/waitlist -H "X-User-Id: 3"
+```
+
+### 에러 응답 포맷
+
+```json
+{
+  "code": "CAPACITY_EXCEEDED",
+  "message": "정원이 초과되었습니다",
+  "timestamp": "2026-04-19T14:00:00",
+  "path": "/enrollments"
+}
+```
 
 ## 데이터 모델 설명
 
-_(추후 작성)_
+### 테이블
+
+| 테이블 | 책임 |
+|--------|------|
+| `users` | 사용자 식별 + 역할 구분 (CREATOR / CLASSMATE) |
+| `classes` | 강의 정보 + 현재 신청 수(`enrolled_count`, 역정규화 + 락 대상) |
+| `enrollments` | 수강 신청 이력 + 상태 (PENDING / CONFIRMED / CANCELLED) |
+| `payments` | 결제 이력 (append-only, PAID / REFUNDED / FAILED) |
+| `waitlists` | 대기열 (WAITING / PROMOTED / CANCELLED) |
+
+### 연관 관계 (모두 단방향 `@ManyToOne`)
+
+- User → Class(`created_by` FK) : 강사가 여러 강의를 개설
+- User → Enrollment(`user_id` FK) : 수강생이 여러 신청
+- Class → Enrollment(`class_id` FK)
+- Enrollment → Payment(`enrollment_id` FK)
+- Class → Waitlist, User → Waitlist
+- Waitlist → Enrollment(`promoted_enrollment_id` FK, 승격 시에만)
+
+양방향 매핑은 JSON 순환 참조 + N+1 위험이 커서 역참조는 모두 Repository 쿼리로 명시적 처리.
+
+### 상태 머신
+
+```
+Class:       DRAFT  ──publish──▶  OPEN  ──close──▶  CLOSED
+Enrollment:  PENDING ──pay──▶ CONFIRMED ──cancel(7일 이내)──▶ CANCELLED
+                │                                                ▲
+                └──────cancel(결제 전 자유)──────────────────────┘
+Waitlist:    WAITING ──promote──▶ PROMOTED (terminal)
+                │
+                └──cancel──▶ CANCELLED (terminal, 재등록은 새 row)
+Payment:     append-only (상태 전이 없음, 각 row 독립)
+```
 
 ## 요구사항 해석 및 가정
 
-_(추후 작성)_
+1. **인증은 X-User-Id 헤더로 단순화**. Spring Security / JWT는 범위 밖. 실서비스에선 게이트웨이에서 주입되는 구조를 가정
+2. **좌석 차감 시점**: 수강 신청(PENDING 생성) 시점. 결제 이전이라도 좌석을 즉시 점유(홀드)하여 "결제 완료 후 좌석 없음" 상황 방지
+3. **결제 시뮬레이션**: 외부 PG 연동 없이 `PATCH /enrollments/{id}/pay` 호출 시 즉시 `PAID` row를 INSERT. `pg_transaction_id`, 콜백 등은 미구현
+4. **취소 가능 기간**: CONFIRMED 이후 7일을 상수로 박음. 강의별 정책은 추후 `ClassEntity`로 이동 가능
+5. **사용자 역할**: 한 User가 CREATOR 겸 CLASSMATE일 수 있음. `role` 컬럼은 힌트이고 실제 권한은 리소스 소유권(FK) 기반 판단
+6. **강사 본인 강의 수강**: 허용. 요구사항에 금지 조항 없음
+7. **수강 취소 후 재신청**: 허용. 중복 신청 방지 인덱스는 활성 상태(`PENDING`, `CONFIRMED`)에만 적용
+8. **환불 처리**: CONFIRMED 상태에서 취소 시 `payments` 테이블에 `REFUNDED` row 자동 INSERT. 실제 금전 환불은 PG 영역이라 이력만 기록
+9. **DELETE 메서드 부재**: 모든 삭제는 상태 전이로 대체하여 이력 보존
 
 ## 설계 결정과 이유
 
-_(추후 작성)_
+### 1. 좌석 차감 타이밍 — 신청 시점(PENDING)
+- 결제 시점 차감이면 "결제 완료 후 좌석 없음" 경쟁이 발생
+- 여러 사용자가 PENDING 상태에서 동시 결제 시도 시 한 명만 성공, 나머지는 환불 지옥
+- 동시성 제어 지점을 **신청 API 1곳**으로 단일화
+
+### 2. 동시성 제어 — 비관적 락 `SELECT ... FOR UPDATE`
+- 인기 강의는 충돌 빈도가 높아 낙관적 락(`@Version`)은 재시도 비용 큼
+- `classes` row 단일 락으로 신청/취소/대기 승격 전부 직렬화
+- 10-스레드 동시 신청 시나리오 테스트(`EnrollmentConcurrencyTest`, `WaitlistConcurrencyTest`)로 검증
+
+### 3. 역정규화 — `classes.enrolled_count`
+- 강의 목록 조회 시 매번 `SELECT COUNT(*) FROM enrollments`는 N+1
+- `enrolled_count` 컬럼 유지 + `CHECK (enrolled_count <= capacity)` DB 레벨 불변식
+- 3중 방어: 서비스 체크 + 엔티티 도메인 메서드 + DB CHECK
+
+### 4. 중복 신청 방지 — PostgreSQL 부분 유니크 인덱스
+```sql
+CREATE UNIQUE INDEX uk_active_enrollment
+    ON enrollments(class_id, user_id)
+    WHERE status IN ('PENDING', 'CONFIRMED');
+```
+- 취소 후 재신청은 허용(CANCELLED는 인덱스 밖), 동일 강의 중복 활성 신청은 차단
+- MySQL이었다면 Generated Column 우회 필요 — PostgreSQL 선택으로 스키마 단순화
+
+### 5. 결제는 append-only
+- `payments.status`는 전이 없이 새 row INSERT
+- 결제 완료: `PAID` INSERT, 환불: `REFUNDED` INSERT, 실패: `FAILED` INSERT (현재 미구현)
+- `uk_payment_paid WHERE status='PAID'` 부분 유니크 인덱스로 이중 결제 DB 차단
+- 감사(audit)/환불 추적이 쉬움
+
+### 6. 대기열 — 수동 등록 + 자동 승격
+- 정원 초과 응답(`CAPACITY_EXCEEDED`) 받은 클라이언트가 명시적으로 `POST /classes/{id}/waitlist` 호출 (자동 대기 안 함)
+- 수강 취소 발생 시 `EnrollmentService.cancel()` 말미에서 `WaitlistService.promoteNext()` 동기 호출 → 선두 자동 승격
+- 선두가 이미 다른 경로로 활성 신청을 가지고 있으면 `skip` 후 다음 선두로 (방어 while 루프)
+- 자동 승격 시 `Enrollment`는 `PENDING` 상태로 생성되어 승격자가 결제만 하면 수강 확정
+
+### 7. 역할(Role) 검증 — 강의 등록에만 적용
+- `POST /classes`는 `CREATOR` 역할만 허용 (`FORBIDDEN_ROLE`)
+- 수정/공개/마감/수강생 목록 조회는 "본인 강의"(소유권) 검증만으로 충분
+- 한 User가 CREATOR + CLASSMATE 모두 가능 (기획 가정)
 
 ## 테스트 실행 방법
 
-_(추후 작성)_
+```bash
+cd enrollment-api
+
+# 전체 테스트
+./gradlew test
+
+# 커버리지 리포트 (JaCoCo)
+./gradlew test jacocoTestReport
+open build/reports/jacoco/test/html/index.html
+```
+
+### 테스트 구성 (총 212 tests)
+
+| 계층 | 프레임워크 | 주요 대상 |
+|------|----------|---------|
+| Entity 단위 | JUnit 5 | 상태 머신, 도메인 메서드 검증 |
+| Service 단위 | Mockito | 비즈니스 로직, 에러 경로 |
+| Repository 통합 | `@DataJpaTest` + Testcontainers PostgreSQL | CHECK 제약, 부분 유니크 인덱스, JOIN FETCH |
+| Controller 슬라이스 | `@WebMvcTest` + `@Import(GlobalExceptionHandler)` | HTTP 상태 / 에러 코드 매핑 |
+| 동시성 통합 | `@SpringBootTest` + Testcontainers | 10-스레드 정원 경쟁, net-zero 불변식 |
+
+Testcontainers가 Docker 컨테이너로 실제 PostgreSQL 15를 띄워 Flyway 마이그레이션(V1~V6)까지 실행하므로 프로덕션과 동일한 환경에서 검증.
 
 ## 미구현 / 제약사항
 
-_(추후 작성)_
+| 항목 | 이유 / 확장 방향 |
+|------|----------------|
+| **인증/인가 체계** | `X-User-Id` 헤더 신뢰. 실제 환경에선 Spring Security + JWT/게이트웨이로 대체 |
+| **PG 실제 연동** | 외부 결제 시스템 범위 밖. `PAID` 상태 단순 기록. 확장 시 `PENDING_APPROVAL` 중간 상태 + 콜백 핸들러 + `pg_transaction_id` 컬럼 추가 |
+| **PENDING TTL** | 결제 지연 시 좌석이 무한 홀드. 확장 시 `expires_at` 컬럼 + `@Scheduled` 1분 배치로 만료 CANCELLED + 다음 대기자 자동 승격 체인 |
+| **대기열 승격 알림** | 이메일/푸시/WebSocket 등 통신 레이어는 범위 밖. 승격자는 `/enrollments/me` 조회로 PENDING 확인 후 결제 |
+| **대기 순번 조회 API** | MVP에서 제외. 필요 시 `ROW_NUMBER() OVER` 기반 별도 엔드포인트 추가 |
+| **다중 서버 확장** | 단일 인스턴스 기준 비관적 락. 수평 확장 시 Redis 분산락(Redisson) 추가 필요 |
+| **강의 기간 종료 자동 마감** | `end_date` 경과 시 자동 CLOSED 전환 미구현. `@Scheduled` 자정 배치로 확장 가능 |
+| **DRAFT 강의 삭제** | 물리 삭제 미지원. 현재 정책상 모든 삭제는 상태 전이(CANCELLED / CLOSED)로 대체 |
 
 ## AI 활용 범위
 
-_(추후 작성)_
+- **코드 생성**: Spring Boot 기본 구조, Repository/Service/Controller 레이어 보일러플레이트를 Claude Code CLI(Sonnet 4.6 / Opus 4.7)로 초안 생성 후 수정·검토
+- **설계 검토**: 동시성 락 전략, 역정규화 구조, 부분 유니크 인덱스 사용 여부 등 의사결정 전에 AI와 trade-off 대화로 검증
+- **테스트 시나리오 발굴**: 엣지 케이스(7일 경계값, 10-스레드 경쟁, 부분 유니크 인덱스 양방향) 후보 제안 및 리뷰
+- **문서 정리**: README / 커밋 메시지 초안
+- **제외**: 비즈니스 요구사항 해석과 최종 설계 결정은 직접 수행. AI 출력은 전부 수동 검토 후 반영
+
+주요 프롬프트 패턴은 "X 대신 Y로 바꾸면 어떤 trade-off가 있나?", "이 코드에서 실무적으로 지적될 수 있는 부분은?" 같은 **비판/검토 질문**. 코드를 그대로 쓰지 않고 프로젝트 컨벤션에 맞게 재작성.

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
@@ -123,6 +123,11 @@ public class ClassEntity extends BaseEntity {
         this.enrolledCount++;
     }
 
+    // 정원 여유 확인
+    public boolean hasVacancy() {
+        return this.enrolledCount < this.capacity;
+    }
+
     // 수강생 수 감소
     public void decrementEnrolled() {
         if (this.enrolledCount <= 0) {

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentCreateRequest.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentCreateRequest.java
@@ -4,5 +4,4 @@ import jakarta.validation.constraints.NotNull;
 
 public record EnrollmentCreateRequest(
         @NotNull Long classId
-) {
-}
+) {}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentResponse.java
@@ -14,6 +14,7 @@ public record EnrollmentResponse(
         LocalDateTime cancelledAt
 ) {
 
+    // 수강 신청 응답 생성
     public static EnrollmentResponse from(Enrollment enrollment) {
         return new EnrollmentResponse(
                 enrollment.getId(),

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentWithUserResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentWithUserResponse.java
@@ -12,6 +12,7 @@ public record EnrollmentWithUserResponse(
         LocalDateTime enrolledAt
 ) {
 
+    // 수강 신청 응답 생성
     public static EnrollmentWithUserResponse from(Enrollment enrollment) {
         return new EnrollmentWithUserResponse(
                 enrollment.getId(),

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
@@ -60,12 +60,14 @@ public class Enrollment extends BaseEntity {
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
 
+    // 수강 신청 확정
     public void confirm() {
         validateTransition(EnrollmentStatus.CONFIRMED);
         this.status = EnrollmentStatus.CONFIRMED;
         this.confirmedAt = LocalDateTime.now();
     }
 
+    // 수강 신청 취소
     public void cancel() {
         if (this.status == EnrollmentStatus.CANCELLED) {
             throw new BusinessException(ErrorCode.ALREADY_CANCELLED);
@@ -81,12 +83,14 @@ public class Enrollment extends BaseEntity {
         this.cancelledAt = LocalDateTime.now();
     }
 
+    // 수강 신청 소유자 검증
     public void validateOwner(Long userId) {
         if (this.user == null || !this.user.getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NOT_ENROLLMENT_OWNER);
         }
     }
 
+    // 상태 전환 검증
     private void validateTransition(EnrollmentStatus target) {
         if (!this.status.canTransitionTo(target)) {
             throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/EnrollmentStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/EnrollmentStatus.java
@@ -3,6 +3,7 @@ package com.enrollment.domain.enrollment.entity;
 public enum EnrollmentStatus {
     PENDING, CONFIRMED, CANCELLED;
 
+    // 상태 전환 가능 여부 검증
     public boolean canTransitionTo(EnrollmentStatus target) {
         return switch (this) {
             case PENDING -> target == CONFIRMED || target == CANCELLED;

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
@@ -40,4 +41,10 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             @Param("classId") Long classId,
             @Param("userId") Long userId,
             @Param("statuses") Collection<EnrollmentStatus> statuses);
+
+    // 활성 수강 신청(PENDING/CONFIRMED) 존재 여부 검증
+    default boolean existsActiveByClassIdAndUserId(Long classId, Long userId) {
+        return existsByClassIdAndUserIdAndStatusIn(classId, userId,
+                List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED));
+    }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -13,6 +13,7 @@ import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
 import com.enrollment.domain.payment.repository.PaymentRepository;
 import com.enrollment.domain.user.entity.User;
 import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.service.WaitlistService;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -36,11 +37,12 @@ public class EnrollmentService {
     private final PaymentRepository paymentRepository;
     private final ClassRepository classRepository;
     private final UserRepository userRepository;
+    private final WaitlistService waitlistService;
 
     // 수강 신청
     @Transactional
     public EnrollmentResponse enroll(Long userId, EnrollmentCreateRequest request) {
-
+        
         // 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -76,7 +78,7 @@ public class EnrollmentService {
     // 결제
     @Transactional
     public EnrollmentResponse pay(Long userId, Long enrollmentId) {
-
+        
         // 수강 신청 조회 (본인 row 상태 변경만이라 락 불필요, 상태머신 + uk_payment_paid 부분 유니크 인덱스로 방어)
         Enrollment enrollment = enrollmentRepository.findWithClassAndUserById(enrollmentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
@@ -89,14 +91,14 @@ public class EnrollmentService {
 
         // 결제 저장
         paymentRepository.save(Payment.paid(enrollment, enrollment.getClassEntity().getPrice()));
-
+        
         return EnrollmentResponse.from(enrollment);
     }
 
     // 수강 취소
     @Transactional
     public EnrollmentResponse cancel(Long userId, Long enrollmentId) {
-
+        
         // 수강 신청 조회
         Enrollment enrollment = enrollmentRepository.findByIdForUpdate(enrollmentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
@@ -122,12 +124,15 @@ public class EnrollmentService {
             paymentRepository.save(Payment.refunded(enrollment, classEntity.getPrice()));
         }
 
+        // 대기열 선두 자동 승격
+        waitlistService.promoteNext(classEntity);
+
         return EnrollmentResponse.from(enrollment);
     }
 
     // 내 수강 신청 목록 조회
     public Page<EnrollmentResponse> getMyEnrollments(Long userId, Pageable pageable) {
-
+        
         // 사용자 존재 여부 검증
         if (!userRepository.existsById(userId)) {
             throw new BusinessException(ErrorCode.USER_NOT_FOUND);
@@ -139,7 +144,7 @@ public class EnrollmentService {
 
     // 강의별 수강생 목록 조회 (강사 전용)
     public Page<EnrollmentWithUserResponse> getClassEnrollments(Long userId, Long classId, Pageable pageable) {
-
+        
         // 강의 조회
         ClassEntity classEntity = classRepository.findWithCreatorById(classId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));

--- a/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/Payment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/Payment.java
@@ -48,6 +48,7 @@ public class Payment extends BaseEntity {
     @Column(name = "paid_at", nullable = false)
     private LocalDateTime paidAt;
 
+    // 결제 완료
     public static Payment paid(Enrollment enrollment, Integer amount) {
         return Payment.builder()
                 .enrollment(enrollment)
@@ -57,6 +58,7 @@ public class Payment extends BaseEntity {
                 .build();
     }
 
+    // 결제 취소
     public static Payment refunded(Enrollment enrollment, Integer amount) {
         return Payment.builder()
                 .enrollment(enrollment)

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/controller/WaitlistController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/controller/WaitlistController.java
@@ -1,0 +1,69 @@
+package com.enrollment.domain.waitlist.controller;
+
+import com.enrollment.domain.waitlist.dto.WaitlistResponse;
+import com.enrollment.domain.waitlist.service.WaitlistService;
+import com.enrollment.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Waitlist API", description = "대기열 관리 API")
+@RestController
+@RequestMapping("/classes/{classId}/waitlist")
+@RequiredArgsConstructor
+public class WaitlistController {
+
+    private final WaitlistService waitlistService;
+
+    @Operation(summary = "대기열 등록", description = "정원이 찬 강의에 대기열로 등록합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "대기열 등록 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = WaitlistResponse.class))),
+        @ApiResponse(responseCode = "400", description = "대기열 등록 불가 상태 (WAITLIST_NOT_ALLOWED, INVALID_INPUT)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자 또는 강의를 찾을 수 없음 (USER_NOT_FOUND, CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "409", description = "이미 신청 또는 대기 중 (ALREADY_ENROLLED, ALREADY_IN_WAITLIST)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping
+    public ResponseEntity<WaitlistResponse> register(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long classId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(waitlistService.register(userId, classId));
+    }
+
+    @Operation(summary = "대기열 철회", description = "본인이 등록한 대기열을 철회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "대기열 철회 성공"),
+        @ApiResponse(responseCode = "403", description = "대기열 소유자가 아님 (NOT_WAITLIST_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "대기열 정보를 찾을 수 없음 (WAITLIST_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> cancel(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long classId) {
+        waitlistService.cancelWaitlist(userId, classId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/dto/WaitlistResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/dto/WaitlistResponse.java
@@ -1,0 +1,24 @@
+package com.enrollment.domain.waitlist.dto;
+
+import com.enrollment.domain.waitlist.entity.Waitlist;
+
+import java.time.LocalDateTime;
+
+public record WaitlistResponse(
+        Long waitlistId,
+        Long classId,
+        String classTitle,
+        String status,
+        LocalDateTime createdAt
+) {
+
+    public static WaitlistResponse from(Waitlist waitlist) {
+        return new WaitlistResponse(
+                waitlist.getId(),
+                waitlist.getClassEntity().getId(),
+                waitlist.getClassEntity().getTitle(),
+                waitlist.getStatus().name(),
+                waitlist.getCreatedAt()
+        );
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/entity/Waitlist.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/entity/Waitlist.java
@@ -1,0 +1,99 @@
+package com.enrollment.domain.waitlist.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.global.entity.BaseEntity;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "waitlists")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Waitlist extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "waitlist_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "class_id", nullable = false)
+    private ClassEntity classEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private WaitlistStatus status;
+
+    @Column(name = "promoted_enrollment_id")
+    private Long promotedEnrollmentId;
+
+    @Column(name = "promoted_at")
+    private LocalDateTime promotedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    // 대기열 승격
+    public void promote(Long enrollmentId) {
+        validateTransition(WaitlistStatus.PROMOTED);
+        this.status = WaitlistStatus.PROMOTED;
+        this.promotedEnrollmentId = enrollmentId;
+        this.promotedAt = LocalDateTime.now();
+    }
+
+    // 대기열 철회
+    public void cancel() {
+        if (this.status == WaitlistStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.ALREADY_CANCELLED);
+        }
+        validateTransition(WaitlistStatus.CANCELLED);
+        this.status = WaitlistStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    // 선두 스킵 — 승격 시 이미 활성 수강 신청을 가진 대기자를 건너뛰기 위한 방어 처리.
+    // 호출부(WaitlistService.promoteNext)가 WAITING 상태만 넘겨주는 것을 보장하므로 상태머신 검증 생략.
+    public void skip() {
+        this.status = WaitlistStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    // 대기열 소유자 검증
+    public void validateOwner(Long userId) {
+        if (this.user == null || !this.user.getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOT_WAITLIST_OWNER);
+        }
+    }
+
+    // 상태 전환 검증
+    private void validateTransition(WaitlistStatus target) {
+        if (!this.status.canTransitionTo(target)) {
+            throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/entity/WaitlistStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/entity/WaitlistStatus.java
@@ -1,0 +1,14 @@
+package com.enrollment.domain.waitlist.entity;
+
+public enum WaitlistStatus {
+    WAITING, PROMOTED, CANCELLED;
+
+    // 상태 전환 가능 여부 검증
+    public boolean canTransitionTo(WaitlistStatus target) {
+        return switch (this) {
+            case WAITING -> target == PROMOTED || target == CANCELLED;
+            case PROMOTED -> false;
+            case CANCELLED -> false;
+        };
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/repository/WaitlistRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/repository/WaitlistRepository.java
@@ -1,0 +1,42 @@
+package com.enrollment.domain.waitlist.repository;
+
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WaitlistRepository extends JpaRepository<Waitlist, Long> {
+
+    // 대기열 선두 비관적 락 조회 (FIFO: createdAt ASC, id ASC 타이브레이커). Pageable.ofSize(1) 로 LIMIT 1
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT w FROM Waitlist w JOIN FETCH w.user "
+            + "WHERE w.classEntity.id = :classId AND w.status = com.enrollment.domain.waitlist.entity.WaitlistStatus.WAITING "
+            + "ORDER BY w.createdAt ASC, w.id ASC")
+    List<Waitlist> findWaitingForUpdate(@Param("classId") Long classId, Pageable pageable);
+
+    // 대기열 선두 단건 조회 편의 메서드
+    default Optional<Waitlist> findFirstWaitingForUpdate(Long classId) {
+        return findWaitingForUpdate(classId, Pageable.ofSize(1)).stream().findFirst();
+    }
+
+    // 대기열 존재 여부 검증
+    @Query("SELECT (COUNT(w) > 0) FROM Waitlist w "
+            + "WHERE w.classEntity.id = :classId AND w.user.id = :userId AND w.status = :status")
+    boolean existsByClassIdAndUserIdAndStatus(@Param("classId") Long classId,
+                                              @Param("userId") Long userId,
+                                              @Param("status") WaitlistStatus status);
+
+    // 대기열 단건 조회
+    @Query("SELECT w FROM Waitlist w "
+            + "WHERE w.classEntity.id = :classId AND w.user.id = :userId AND w.status = :status")
+    Optional<Waitlist> findByClassIdAndUserIdAndStatus(@Param("classId") Long classId,
+                                                      @Param("userId") Long userId,
+                                                      @Param("status") WaitlistStatus status);
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/service/WaitlistService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/service/WaitlistService.java
@@ -1,0 +1,127 @@
+package com.enrollment.domain.waitlist.service;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.dto.WaitlistResponse;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.domain.waitlist.repository.WaitlistRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WaitlistService {
+
+    private final WaitlistRepository waitlistRepository;
+    private final EnrollmentRepository enrollmentRepository;
+    private final ClassRepository classRepository;
+    private final UserRepository userRepository;
+
+    // 대기열 등록
+    @Transactional
+    public WaitlistResponse register(Long userId, Long classId) {
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 강의 조회 (읽기 전용이라 락 불필요, uk_active_waitlist 유니크 인덱스로 중복 대기 차단)
+        ClassEntity classEntity = classRepository.findById(classId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 강의 상태 검증
+        if (classEntity.getStatus() != ClassStatus.OPEN) {
+            throw new BusinessException(ErrorCode.WAITLIST_NOT_ALLOWED);
+        }
+
+        // 정원 여유 검증
+        if (classEntity.hasVacancy()) {
+            throw new BusinessException(ErrorCode.WAITLIST_NOT_ALLOWED);
+        }
+
+        // 활성 수강 신청 존재 여부 검증
+        if (enrollmentRepository.existsActiveByClassIdAndUserId(classId, userId)) {
+            throw new BusinessException(ErrorCode.ALREADY_ENROLLED);
+        }
+
+        // 대기열 중복 검증
+        if (waitlistRepository.existsByClassIdAndUserIdAndStatus(classId, userId, WaitlistStatus.WAITING)) {
+            throw new BusinessException(ErrorCode.ALREADY_IN_WAITLIST);
+        }
+
+        // 대기열 저장
+        return WaitlistResponse.from(waitlistRepository.save(
+                Waitlist.builder()
+                        .classEntity(classEntity)
+                        .user(user)
+                        .status(WaitlistStatus.WAITING)
+                        .build()));
+    }
+
+    // 대기열 철회
+    @Transactional
+    public void cancelWaitlist(Long userId, Long classId) {
+
+        // 대기열 조회
+        Waitlist waitlist = waitlistRepository
+                .findByClassIdAndUserIdAndStatus(classId, userId, WaitlistStatus.WAITING)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WAITLIST_NOT_FOUND));
+
+        // 대기열 소유자 검증
+        waitlist.validateOwner(userId);
+
+        // 대기열 취소
+        waitlist.cancel();
+    }
+
+    // 선두 자동 승격 (EnrollmentService.cancel 내부에서 호출, 같은 트랜잭션)
+    @Transactional
+    public void promoteNext(ClassEntity classEntity) {
+        while (true) {
+
+            // 선두 대기열 조회
+            Optional<Waitlist> found = waitlistRepository.findFirstWaitingForUpdate(classEntity.getId());
+            if (found.isEmpty()) {
+                return;
+            }
+            Waitlist next = found.get();
+
+            // 선두가 이미 활성 수강 신청 보유 시 skip
+            if (enrollmentRepository.existsActiveByClassIdAndUserId(
+                    classEntity.getId(), next.getUser().getId())) {
+                next.skip();
+                continue;
+            }
+
+            // 좌석 재차지
+            classEntity.incrementEnrolled();
+
+            // PENDING 수강 신청 생성
+            Enrollment promoted = enrollmentRepository.save(
+                    Enrollment.builder()
+                            .classEntity(classEntity)
+                            .user(next.getUser())
+                            .status(EnrollmentStatus.PENDING)
+                            .enrolledAt(LocalDateTime.now())
+                            .build());
+
+            // 대기열 승격
+            next.promote(promoted.getId());
+            break;
+        }
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
@@ -13,19 +13,23 @@ public enum ErrorCode {
     CANCEL_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "CANCEL_PERIOD_EXPIRED", "취소 가능 기간(7일)을 초과했습니다"),
     ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "ALREADY_CANCELLED", "이미 취소된 수강 신청입니다"),
     INVALID_STATE_TRANSITION(HttpStatus.BAD_REQUEST, "INVALID_STATE_TRANSITION", "허용되지 않은 상태 전이입니다"),
+    WAITLIST_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "WAITLIST_NOT_ALLOWED", "대기열에 등록할 수 없습니다"),
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다"),
 
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "권한이 없습니다"),
     NOT_COURSE_OWNER(HttpStatus.FORBIDDEN, "NOT_COURSE_OWNER", "해당 강의의 소유자가 아닙니다"),
     NOT_ENROLLMENT_OWNER(HttpStatus.FORBIDDEN, "NOT_ENROLLMENT_OWNER", "본인의 수강 신청만 수정할 수 있습니다"),
+    NOT_WAITLIST_OWNER(HttpStatus.FORBIDDEN, "NOT_WAITLIST_OWNER", "본인의 대기열만 철회할 수 있습니다"),
     FORBIDDEN_ROLE(HttpStatus.FORBIDDEN, "FORBIDDEN_ROLE", "해당 역할은 이 작업을 수행할 수 없습니다"),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다"),
     CLASS_NOT_FOUND(HttpStatus.NOT_FOUND, "CLASS_NOT_FOUND", "강의를 찾을 수 없습니다"),
     ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ENROLLMENT_NOT_FOUND", "수강 신청 내역을 찾을 수 없습니다"),
+    WAITLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "WAITLIST_NOT_FOUND", "대기열 정보를 찾을 수 없습니다"),
 
     ALREADY_ENROLLED(HttpStatus.CONFLICT, "ALREADY_ENROLLED", "이미 신청한 강의입니다"),
+    ALREADY_IN_WAITLIST(HttpStatus.CONFLICT, "ALREADY_IN_WAITLIST", "이미 대기열에 등록되어 있습니다"),
 
     LOCK_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "LOCK_TIMEOUT", "요청이 혼잡합니다. 잠시 후 다시 시도해주세요"),
 

--- a/enrollment-api/src/main/resources/db/migration/V6__create_waitlists_table.sql
+++ b/enrollment-api/src/main/resources/db/migration/V6__create_waitlists_table.sql
@@ -1,0 +1,31 @@
+CREATE TABLE waitlists (
+    waitlist_id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    class_id                BIGINT NOT NULL REFERENCES classes(class_id),
+    user_id                 BIGINT NOT NULL REFERENCES users(user_id),
+    status                  VARCHAR(20) NOT NULL,
+    promoted_enrollment_id  BIGINT REFERENCES enrollments(enrollment_id),
+    promoted_at             TIMESTAMP(6),
+    cancelled_at            TIMESTAMP(6),
+    created_at              TIMESTAMP(6) NOT NULL,
+    updated_at              TIMESTAMP(6) NOT NULL,
+    CONSTRAINT chk_waitlist_status CHECK (status IN ('WAITING', 'PROMOTED', 'CANCELLED')),
+    CONSTRAINT chk_waitlist_promotion CHECK (
+        (status = 'PROMOTED' AND promoted_enrollment_id IS NOT NULL AND promoted_at IS NOT NULL)
+        OR (status <> 'PROMOTED')
+    ),
+    CONSTRAINT chk_waitlist_cancelled CHECK (
+        (status = 'CANCELLED' AND cancelled_at IS NOT NULL)
+        OR (status <> 'CANCELLED' AND cancelled_at IS NULL)
+    )
+);
+
+CREATE INDEX idx_waitlists_class_id ON waitlists(class_id);
+CREATE INDEX idx_waitlists_user_id ON waitlists(user_id);
+
+-- 한 유저는 한 강의에 1 WAITING만 (CANCELLED 후 재대기 허용)
+CREATE UNIQUE INDEX uk_active_waitlist ON waitlists(class_id, user_id)
+    WHERE status = 'WAITING';
+
+-- FIFO 승격 + 동일 시각 타이브레이커
+CREATE INDEX idx_waitlist_fifo ON waitlists(class_id, created_at, waitlist_id)
+    WHERE status = 'WAITING';

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
@@ -15,6 +15,7 @@ import com.enrollment.domain.payment.repository.PaymentRepository;
 import com.enrollment.domain.user.entity.User;
 import com.enrollment.domain.user.entity.UserRole;
 import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.service.WaitlistService;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +57,8 @@ class EnrollmentServiceTest {
     ClassRepository classRepository;
     @Mock
     UserRepository userRepository;
+    @Mock
+    WaitlistService waitlistService;
     @InjectMocks
     EnrollmentService enrollmentService;
 

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/WaitlistConcurrencyTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/WaitlistConcurrencyTest.java
@@ -1,0 +1,264 @@
+package com.enrollment.domain.waitlist;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.domain.waitlist.repository.WaitlistRepository;
+import com.enrollment.domain.waitlist.service.WaitlistService;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class WaitlistConcurrencyTest extends AbstractIntegrationTest {
+
+    @Autowired
+    EnrollmentService enrollmentService;
+    @Autowired
+    WaitlistService waitlistService;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    EnrollmentRepository enrollmentRepository;
+    @Autowired
+    WaitlistRepository waitlistRepository;
+    @Autowired
+    TransactionTemplate transactionTemplate;
+
+    private User creator;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build());
+    }
+
+    @Test
+    void 정원_1_CONFIRMED_1명_대기_3명_상태에서_1건_취소_시_정확히_1명_승격() throws Exception {
+        // 정원 1, CONFIRMED 1명 + WAITING 3명
+        User confirmedUser = userRepository.saveAndFlush(
+                User.builder().name("confirmed").role(UserRole.CLASSMATE).build());
+        List<Long> waitingUserIds = IntStream.range(0, 3)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("waiting" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("마감_강의").description("정원 1")
+                        .price(10000).capacity(1).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+        Long classId = openClass.getId();
+
+        // CONFIRMED 수강 신청 선삽입
+        Enrollment confirmed = transactionTemplate.execute(status ->
+                enrollmentRepository.saveAndFlush(
+                        Enrollment.builder()
+                                .classEntity(classRepository.findById(classId).orElseThrow())
+                                .user(userRepository.findById(confirmedUser.getId()).orElseThrow())
+                                .status(EnrollmentStatus.CONFIRMED)
+                                .enrolledAt(LocalDateTime.now())
+                                .confirmedAt(LocalDateTime.now())
+                                .build()));
+
+        // WAITING 3명 선삽입
+        for (Long waitingId : waitingUserIds) {
+            transactionTemplate.executeWithoutResult(s ->
+                    waitlistRepository.saveAndFlush(
+                            Waitlist.builder()
+                                    .classEntity(classRepository.findById(classId).orElseThrow())
+                                    .user(userRepository.findById(waitingId).orElseThrow())
+                                    .status(WaitlistStatus.WAITING)
+                                    .build()));
+        }
+
+        // CONFIRMED 취소 실행
+        enrollmentService.cancel(confirmedUser.getId(), confirmed.getId());
+
+        // 검증
+        ClassEntity finalClass = classRepository.findById(classId).orElseThrow();
+        assertThat(finalClass.getEnrolledCount()).isEqualTo(1);
+
+        long promotedCount = waitlistRepository.findAll().stream()
+                .filter(w -> w.getClassEntity().getId().equals(classId)
+                        && w.getStatus() == WaitlistStatus.PROMOTED)
+                .count();
+        assertThat(promotedCount).isEqualTo(1);
+
+        long pendingEnrollments = enrollmentRepository.findAll().stream()
+                .filter(e -> e.getClassEntity().getId().equals(classId)
+                        && e.getStatus() == EnrollmentStatus.PENDING)
+                .count();
+        assertThat(pendingEnrollments).isEqualTo(1);
+    }
+
+    @Test
+    void 정원_10_CONFIRMED_10명_대기_10명_상태에서_2건_동시_취소_시_2명_승격_net_zero() throws Exception {
+        // 정원 10, CONFIRMED 10 + WAITING 10
+        List<Long> confirmedUserIds = IntStream.range(0, 10)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("confirmed" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+        List<Long> waitingUserIds = IntStream.range(0, 10)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("waiting" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("인기_강의").description("정원 10")
+                        .price(10000).capacity(10).enrolledCount(10)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+        Long classId = openClass.getId();
+
+        // CONFIRMED 10명 선삽입
+        List<Long> confirmedEnrollmentIds = confirmedUserIds.stream()
+                .map(uid -> transactionTemplate.execute(s ->
+                        enrollmentRepository.saveAndFlush(
+                                Enrollment.builder()
+                                        .classEntity(classRepository.findById(classId).orElseThrow())
+                                        .user(userRepository.findById(uid).orElseThrow())
+                                        .status(EnrollmentStatus.CONFIRMED)
+                                        .enrolledAt(LocalDateTime.now())
+                                        .confirmedAt(LocalDateTime.now())
+                                        .build()).getId()))
+                .toList();
+
+        // WAITING 10명 선삽입
+        for (Long waitingId : waitingUserIds) {
+            transactionTemplate.executeWithoutResult(s ->
+                    waitlistRepository.saveAndFlush(
+                            Waitlist.builder()
+                                    .classEntity(classRepository.findById(classId).orElseThrow())
+                                    .user(userRepository.findById(waitingId).orElseThrow())
+                                    .status(WaitlistStatus.WAITING)
+                                    .build()));
+        }
+
+        // 동시 취소 2건
+        List<Long> cancelTargets = confirmedEnrollmentIds.subList(0, 2);
+        List<Long> cancelUserIds = confirmedUserIds.subList(0, 2);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(2);
+        AtomicInteger successCount = new AtomicInteger();
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        for (int i = 0; i < 2; i++) {
+            final int idx = i;
+            pool.submit(() -> {
+                try {
+                    startLatch.await();
+                    enrollmentService.cancel(cancelUserIds.get(idx), cancelTargets.get(idx));
+                    successCount.incrementAndGet();
+                } catch (Exception ignored) {
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        boolean finished = doneLatch.await(30, TimeUnit.SECONDS);
+        pool.shutdown();
+
+        assertThat(finished).isTrue();
+        assertThat(successCount.get()).isEqualTo(2);
+
+        // net-zero: enrolledCount 유지 (decrement 2 + increment 2 for promotion)
+        ClassEntity finalClass = classRepository.findById(classId).orElseThrow();
+        assertThat(finalClass.getEnrolledCount()).isEqualTo(10);
+
+        long promotedCount = waitlistRepository.findAll().stream()
+                .filter(w -> w.getClassEntity().getId().equals(classId)
+                        && w.getStatus() == WaitlistStatus.PROMOTED)
+                .count();
+        assertThat(promotedCount).isEqualTo(2);
+    }
+
+    @Test
+    void 다른_유저_5명_동시_register_시_모두_성공() throws Exception {
+        // 정원 찬 강의 준비
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("인기_강의").description("정원 1")
+                        .price(10000).capacity(1).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+        Long classId = openClass.getId();
+
+        List<Long> classmateIds = IntStream.range(0, 5)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("student" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+
+        int threadCount = classmateIds.size();
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+        for (Long classmateId : classmateIds) {
+            pool.submit(() -> {
+                try {
+                    startLatch.await();
+                    waitlistService.register(classmateId, classId);
+                    successCount.incrementAndGet();
+                } catch (Exception ignored) {
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        boolean finished = doneLatch.await(30, TimeUnit.SECONDS);
+        pool.shutdown();
+
+        assertThat(finished).isTrue();
+        assertThat(successCount.get()).isEqualTo(threadCount);
+
+        long waitingCount = waitlistRepository.findAll().stream()
+                .filter(w -> w.getClassEntity().getId().equals(classId)
+                        && w.getStatus() == WaitlistStatus.WAITING)
+                .count();
+        assertThat(waitingCount).isEqualTo(5);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/controller/WaitlistControllerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/controller/WaitlistControllerTest.java
@@ -1,0 +1,157 @@
+package com.enrollment.domain.waitlist.controller;
+
+import com.enrollment.domain.waitlist.dto.WaitlistResponse;
+import com.enrollment.domain.waitlist.service.WaitlistService;
+import com.enrollment.global.error.GlobalExceptionHandler;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(WaitlistController.class)
+@Import(GlobalExceptionHandler.class)
+class WaitlistControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @MockBean
+    WaitlistService waitlistService;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 1, 1, 0, 0);
+
+    private WaitlistResponse sampleResponse() {
+        return new WaitlistResponse(500L, 10L, "Java 기초", "WAITING", NOW);
+    }
+
+    @Nested
+    class Register {
+
+        @Test
+        void 정상_등록_201() throws Exception {
+            given(waitlistService.register(2L, 10L)).willReturn(sampleResponse());
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.waitlistId").value(500))
+                    .andExpect(jsonPath("$.classId").value(10))
+                    .andExpect(jsonPath("$.classTitle").value("Java 기초"))
+                    .andExpect(jsonPath("$.status").value("WAITING"));
+        }
+
+        @Test
+        void WAITLIST_NOT_ALLOWED_시_400() throws Exception {
+            given(waitlistService.register(2L, 10L))
+                    .willThrow(new BusinessException(ErrorCode.WAITLIST_NOT_ALLOWED));
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("WAITLIST_NOT_ALLOWED"));
+        }
+
+        @Test
+        void 강의_미존재_시_404() throws Exception {
+            given(waitlistService.register(2L, 999L))
+                    .willThrow(new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+            mockMvc.perform(post("/classes/999/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
+        }
+
+        @Test
+        void 사용자_미존재_시_404() throws Exception {
+            given(waitlistService.register(999L, 10L))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+        }
+
+        @Test
+        void 이미_신청한_강의면_409() throws Exception {
+            given(waitlistService.register(2L, 10L))
+                    .willThrow(new BusinessException(ErrorCode.ALREADY_ENROLLED));
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("ALREADY_ENROLLED"));
+        }
+
+        @Test
+        void 이미_대기중이면_409() throws Exception {
+            given(waitlistService.register(2L, 10L))
+                    .willThrow(new BusinessException(ErrorCode.ALREADY_IN_WAITLIST));
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("ALREADY_IN_WAITLIST"));
+        }
+
+        @Test
+        void X_User_Id_누락_시_400() throws Exception {
+            mockMvc.perform(post("/classes/10/waitlist"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void 정상_철회_204() throws Exception {
+            doNothing().when(waitlistService).cancelWaitlist(2L, 10L);
+
+            mockMvc.perform(delete("/classes/10/waitlist/me")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 대기열_미존재_시_404() throws Exception {
+            willThrow(new BusinessException(ErrorCode.WAITLIST_NOT_FOUND))
+                    .given(waitlistService).cancelWaitlist(2L, 10L);
+
+            mockMvc.perform(delete("/classes/10/waitlist/me")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("WAITLIST_NOT_FOUND"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            willThrow(new BusinessException(ErrorCode.NOT_WAITLIST_OWNER))
+                    .given(waitlistService).cancelWaitlist(999L, 10L);
+
+            mockMvc.perform(delete("/classes/10/waitlist/me")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_WAITLIST_OWNER"));
+        }
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/entity/WaitlistStatusTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/entity/WaitlistStatusTest.java
@@ -1,0 +1,37 @@
+package com.enrollment.domain.waitlist.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WaitlistStatusTest {
+
+    @Test
+    void WAITING에서_PROMOTED로_전이_가능() {
+        assertThat(WaitlistStatus.WAITING.canTransitionTo(WaitlistStatus.PROMOTED)).isTrue();
+    }
+
+    @Test
+    void WAITING에서_CANCELLED로_전이_가능() {
+        assertThat(WaitlistStatus.WAITING.canTransitionTo(WaitlistStatus.CANCELLED)).isTrue();
+    }
+
+    @Test
+    void PROMOTED에서_어디로도_전이_불가() {
+        assertThat(WaitlistStatus.PROMOTED.canTransitionTo(WaitlistStatus.WAITING)).isFalse();
+        assertThat(WaitlistStatus.PROMOTED.canTransitionTo(WaitlistStatus.CANCELLED)).isFalse();
+    }
+
+    @Test
+    void CANCELLED에서_어디로도_전이_불가() {
+        assertThat(WaitlistStatus.CANCELLED.canTransitionTo(WaitlistStatus.WAITING)).isFalse();
+        assertThat(WaitlistStatus.CANCELLED.canTransitionTo(WaitlistStatus.PROMOTED)).isFalse();
+    }
+
+    @Test
+    void 같은_상태로_전이_불가() {
+        assertThat(WaitlistStatus.WAITING.canTransitionTo(WaitlistStatus.WAITING)).isFalse();
+        assertThat(WaitlistStatus.PROMOTED.canTransitionTo(WaitlistStatus.PROMOTED)).isFalse();
+        assertThat(WaitlistStatus.CANCELLED.canTransitionTo(WaitlistStatus.CANCELLED)).isFalse();
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/entity/WaitlistTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/entity/WaitlistTest.java
@@ -1,0 +1,171 @@
+package com.enrollment.domain.waitlist.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WaitlistTest {
+
+    private User classmate;
+    private ClassEntity openClass;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+
+        classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+
+        openClass = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초")
+                .description("설명")
+                .price(10000)
+                .capacity(1)
+                .enrolledCount(1)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT)
+                .build();
+        setId(openClass, 10L);
+        openClass.publish();
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void create_시_WAITING_상태와_null_필드() {
+            Waitlist waitlist = newWaitlist();
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.WAITING);
+            assertThat(waitlist.getPromotedAt()).isNull();
+            assertThat(waitlist.getPromotedEnrollmentId()).isNull();
+            assertThat(waitlist.getCancelledAt()).isNull();
+            assertThat(waitlist.getClassEntity()).isEqualTo(openClass);
+            assertThat(waitlist.getUser()).isEqualTo(classmate);
+        }
+    }
+
+    @Nested
+    class Promote {
+
+        @Test
+        void WAITING에서_promote_성공() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.promote(555L);
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+            assertThat(waitlist.getPromotedEnrollmentId()).isEqualTo(555L);
+            assertThat(waitlist.getPromotedAt()).isNotNull();
+        }
+
+        @Test
+        void PROMOTED에서_promote_시_INVALID_STATE_TRANSITION() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.promote(555L);
+            assertThatThrownBy(() -> waitlist.promote(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void CANCELLED에서_promote_시_INVALID_STATE_TRANSITION() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.cancel();
+            assertThatThrownBy(() -> waitlist.promote(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void WAITING에서_cancel_성공() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.cancel();
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(waitlist.getCancelledAt()).isNotNull();
+        }
+
+        @Test
+        void PROMOTED에서_cancel_시_INVALID_STATE_TRANSITION() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.promote(555L);
+            assertThatThrownBy(waitlist::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void CANCELLED에서_cancel_시_ALREADY_CANCELLED() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.cancel();
+            assertThatThrownBy(waitlist::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_CANCELLED));
+        }
+    }
+
+    @Nested
+    class Skip {
+
+        @Test
+        void skip_시_예외_없이_CANCELLED로_전환() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.skip();
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(waitlist.getCancelledAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class ValidateOwner {
+
+        @Test
+        void 소유자_일치_시_예외_없음() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.validateOwner(2L);
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_WAITLIST_OWNER_예외() {
+            Waitlist waitlist = newWaitlist();
+            assertThatThrownBy(() -> waitlist.validateOwner(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_WAITLIST_OWNER));
+        }
+    }
+
+    private Waitlist newWaitlist() {
+        return Waitlist.builder()
+                .classEntity(openClass)
+                .user(classmate)
+                .status(WaitlistStatus.WAITING)
+                .build();
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/repository/WaitlistRepositoryTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/repository/WaitlistRepositoryTest.java
@@ -1,0 +1,213 @@
+package com.enrollment.domain.waitlist.repository;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.global.config.JpaAuditingConfig;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Import(JpaAuditingConfig.class)
+class WaitlistRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    TestEntityManager em;
+    @Autowired
+    WaitlistRepository waitlistRepository;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+
+    private User creator;
+    private User classmate;
+    private User otherClassmate;
+    private ClassEntity fullClass;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build()
+        );
+        classmate = userRepository.saveAndFlush(
+                User.builder().name("student").role(UserRole.CLASSMATE).build()
+        );
+        otherClassmate = userRepository.saveAndFlush(
+                User.builder().name("other").role(UserRole.CLASSMATE).build()
+        );
+        fullClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("Java 기초").description("설명")
+                        .price(10000).capacity(1).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build()
+        );
+    }
+
+    @Test
+    void save_시_id_자동_생성_및_auditing() {
+        Waitlist saved = waitlistRepository.saveAndFlush(newWaiting(classmate));
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+        assertThat(saved.getStatus()).isEqualTo(WaitlistStatus.WAITING);
+    }
+
+    @Test
+    void 부분_유니크_인덱스_WAITING_중복_방지() {
+        waitlistRepository.saveAndFlush(newWaiting(classmate));
+        em.clear();
+
+        Waitlist duplicate = newWaiting(classmate);
+        assertThatThrownBy(() -> waitlistRepository.saveAndFlush(duplicate))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 부분_유니크_인덱스_CANCELLED_후_재등록_허용() {
+        Waitlist first = waitlistRepository.saveAndFlush(newWaiting(classmate));
+        first.cancel();
+        waitlistRepository.saveAndFlush(first);
+        em.clear();
+
+        Waitlist secondAttempt = newWaiting(classmate);
+        Waitlist saved = waitlistRepository.saveAndFlush(secondAttempt);
+        assertThat(saved.getId()).isNotNull();
+    }
+
+    @Test
+    void chk_waitlist_promotion_PROMOTED인데_promoted_at_NULL이면_실패() throws Exception {
+        // JPA 라이프사이클을 우회하기 위해 리플렉션으로 필드 직접 설정 후 flush
+        Waitlist waitlist = newWaiting(classmate);
+        setField(waitlist, "status", WaitlistStatus.PROMOTED);
+        setField(waitlist, "promotedEnrollmentId", null);
+        setField(waitlist, "promotedAt", null);
+
+        assertThatThrownBy(() -> waitlistRepository.saveAndFlush(waitlist))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void chk_waitlist_cancelled_CANCELLED인데_cancelled_at_NULL이면_실패() throws Exception {
+        Waitlist waitlist = newWaiting(classmate);
+        setField(waitlist, "status", WaitlistStatus.CANCELLED);
+        setField(waitlist, "cancelledAt", null);
+
+        assertThatThrownBy(() -> waitlistRepository.saveAndFlush(waitlist))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void findFirstWaitingForUpdate_FIFO_순서로_선두_조회() throws Exception {
+        // 타이브레이커 확인 위해 createdAt을 동일하게 강제 설정
+        Waitlist first = waitlistRepository.saveAndFlush(newWaiting(classmate));
+        Waitlist second = waitlistRepository.saveAndFlush(newWaiting(otherClassmate));
+
+        LocalDateTime sameInstant = LocalDateTime.now();
+        setField(first, "createdAt", sameInstant);
+        setField(second, "createdAt", sameInstant);
+        waitlistRepository.saveAndFlush(first);
+        waitlistRepository.saveAndFlush(second);
+        em.clear();
+
+        Optional<Waitlist> found = waitlistRepository.findFirstWaitingForUpdate(fullClass.getId());
+        assertThat(found).isPresent();
+        // id 타이브레이커로 더 작은 id(first)가 선두
+        assertThat(found.get().getId()).isEqualTo(first.getId());
+        // JOIN FETCH로 user 즉시 로딩
+        assertThat(found.get().getUser().getName()).isEqualTo("student");
+    }
+
+    @Test
+    void findFirstWaitingForUpdate_createdAt_ASC_정렬() throws Exception {
+        Waitlist earlier = waitlistRepository.saveAndFlush(newWaiting(classmate));
+        Waitlist later = waitlistRepository.saveAndFlush(newWaiting(otherClassmate));
+
+        LocalDateTime base = LocalDateTime.now();
+        setField(earlier, "createdAt", base.minusMinutes(5));
+        setField(later, "createdAt", base);
+        waitlistRepository.saveAndFlush(earlier);
+        waitlistRepository.saveAndFlush(later);
+        em.clear();
+
+        Optional<Waitlist> found = waitlistRepository.findFirstWaitingForUpdate(fullClass.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(earlier.getId());
+    }
+
+    @Test
+    void existsByClassIdAndUserIdAndStatus_WAITING_존재하면_true() {
+        waitlistRepository.saveAndFlush(newWaiting(classmate));
+        em.clear();
+
+        boolean exists = waitlistRepository.existsByClassIdAndUserIdAndStatus(
+                fullClass.getId(), classmate.getId(), WaitlistStatus.WAITING);
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void existsByClassIdAndUserIdAndStatus_미존재시_false() {
+        boolean exists = waitlistRepository.existsByClassIdAndUserIdAndStatus(
+                fullClass.getId(), classmate.getId(), WaitlistStatus.WAITING);
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    void findByClassIdAndUserIdAndStatus_조회_성공() {
+        waitlistRepository.saveAndFlush(newWaiting(classmate));
+        em.clear();
+
+        Optional<Waitlist> found = waitlistRepository.findByClassIdAndUserIdAndStatus(
+                fullClass.getId(), classmate.getId(), WaitlistStatus.WAITING);
+        assertThat(found).isPresent();
+    }
+
+    private Waitlist newWaiting(User user) {
+        return Waitlist.builder()
+                .classEntity(fullClass)
+                .user(user)
+                .status(WaitlistStatus.WAITING)
+                .build();
+    }
+
+    private void setField(Object obj, String name, Object value) throws Exception {
+        Class<?> clazz = obj.getClass();
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField(name);
+                field.setAccessible(true);
+                field.set(obj, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/service/WaitlistServiceTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/service/WaitlistServiceTest.java
@@ -1,0 +1,401 @@
+package com.enrollment.domain.waitlist.service;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.dto.WaitlistResponse;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.domain.waitlist.repository.WaitlistRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class WaitlistServiceTest {
+
+    @Mock
+    WaitlistRepository waitlistRepository;
+    @Mock
+    EnrollmentRepository enrollmentRepository;
+    @Mock
+    ClassRepository classRepository;
+    @Mock
+    UserRepository userRepository;
+    @InjectMocks
+    WaitlistService waitlistService;
+
+    private User creator;
+    private User classmate;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+        classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+    }
+
+    private ClassEntity fullOpenClass(int capacity) throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(capacity).enrolledCount(capacity)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        entity.publish();
+        return entity;
+    }
+
+    private ClassEntity openClassWithVacancy() throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(30).enrolledCount(5)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        entity.publish();
+        return entity;
+    }
+
+    private ClassEntity closedClass() throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(1).enrolledCount(1)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        entity.publish();
+        entity.close();
+        return entity;
+    }
+
+    @Nested
+    class Register {
+
+        @Test
+        void 정상_등록() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(fullClass));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 2L)).willReturn(false);
+            given(waitlistRepository.existsByClassIdAndUserIdAndStatus(
+                    10L, 2L, WaitlistStatus.WAITING)).willReturn(false);
+
+            given(waitlistRepository.save(any(Waitlist.class))).willAnswer(inv -> {
+                Waitlist w = inv.getArgument(0);
+                setId(w, 500L);
+                return w;
+            });
+
+            WaitlistResponse response = waitlistService.register(2L, 10L);
+
+            assertThat(response.waitlistId()).isEqualTo(500L);
+            assertThat(response.classId()).isEqualTo(10L);
+            assertThat(response.classTitle()).isEqualTo("Java 기초");
+            assertThat(response.status()).isEqualTo("WAITING");
+        }
+
+        @Test
+        void 사용자_미존재_시_USER_NOT_FOUND() {
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> waitlistService.register(999L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+
+        @Test
+        void 강의_미존재_시_CLASS_NOT_FOUND() {
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CLASS_NOT_FOUND));
+        }
+
+        @Test
+        void 강의_OPEN_아니면_WAITLIST_NOT_ALLOWED() throws Exception {
+            ClassEntity closed = closedClass();
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(closed));
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.WAITLIST_NOT_ALLOWED));
+        }
+
+        @Test
+        void 정원_남으면_WAITLIST_NOT_ALLOWED() throws Exception {
+            ClassEntity withVacancy = openClassWithVacancy();
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(withVacancy));
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.WAITLIST_NOT_ALLOWED));
+        }
+
+        @Test
+        void 이미_활성_수강_신청이면_ALREADY_ENROLLED() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(fullClass));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 2L)).willReturn(true);
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_ENROLLED));
+        }
+
+        @Test
+        void 이미_대기중이면_ALREADY_IN_WAITLIST() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(fullClass));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 2L)).willReturn(false);
+            given(waitlistRepository.existsByClassIdAndUserIdAndStatus(
+                    10L, 2L, WaitlistStatus.WAITING)).willReturn(true);
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_IN_WAITLIST));
+        }
+    }
+
+    @Nested
+    class CancelWaitlist {
+
+        @Test
+        void 정상_철회() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            Waitlist waitlist = Waitlist.builder()
+                    .classEntity(fullClass).user(classmate)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(waitlist, 500L);
+
+            given(waitlistRepository.findByClassIdAndUserIdAndStatus(
+                    10L, 2L, WaitlistStatus.WAITING)).willReturn(Optional.of(waitlist));
+
+            waitlistService.cancelWaitlist(2L, 10L);
+
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(waitlist.getCancelledAt()).isNotNull();
+        }
+
+        @Test
+        void 대기열_미존재_시_WAITLIST_NOT_FOUND() {
+            given(waitlistRepository.findByClassIdAndUserIdAndStatus(
+                    10L, 2L, WaitlistStatus.WAITING)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> waitlistService.cancelWaitlist(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.WAITLIST_NOT_FOUND));
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_WAITLIST_OWNER() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            Waitlist waitlist = Waitlist.builder()
+                    .classEntity(fullClass).user(classmate)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(waitlist, 500L);
+
+            given(waitlistRepository.findByClassIdAndUserIdAndStatus(
+                    10L, 999L, WaitlistStatus.WAITING)).willReturn(Optional.of(waitlist));
+
+            assertThatThrownBy(() -> waitlistService.cancelWaitlist(999L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_WAITLIST_OWNER));
+        }
+    }
+
+    @Nested
+    class PromoteNext {
+
+        @Test
+        void 대기열_비어있으면_no_op() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            // cancel 이후 상태로 만들기 위해 정원 1 감소
+            setField(fullClass, "enrolledCount", 0);
+
+            given(waitlistRepository.findFirstWaitingForUpdate(10L)).willReturn(Optional.empty());
+
+            waitlistService.promoteNext(fullClass);
+
+            verify(enrollmentRepository, never()).save(any(Enrollment.class));
+            assertThat(fullClass.getEnrolledCount()).isEqualTo(0);
+        }
+
+        @Test
+        void 선두_승격_시_PENDING_신청_생성_및_enrolledCount_증가() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            setField(fullClass, "enrolledCount", 0);
+
+            User waitingUser = User.builder().name("waiter").role(UserRole.CLASSMATE).build();
+            setId(waitingUser, 3L);
+            Waitlist head = Waitlist.builder()
+                    .classEntity(fullClass).user(waitingUser)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(head, 500L);
+
+            given(waitlistRepository.findFirstWaitingForUpdate(10L)).willReturn(Optional.of(head));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 3L)).willReturn(false);
+            AtomicLong idGen = new AtomicLong(777);
+            given(enrollmentRepository.save(any(Enrollment.class))).willAnswer(inv -> {
+                Enrollment e = inv.getArgument(0);
+                setId(e, idGen.getAndIncrement());
+                return e;
+            });
+
+            waitlistService.promoteNext(fullClass);
+
+            ArgumentCaptor<Enrollment> captor = ArgumentCaptor.forClass(Enrollment.class);
+            verify(enrollmentRepository).save(captor.capture());
+            Enrollment saved = captor.getValue();
+            assertThat(saved.getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+            assertThat(saved.getUser().getId()).isEqualTo(3L);
+            assertThat(saved.getEnrolledAt()).isNotNull();
+
+            assertThat(head.getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+            assertThat(head.getPromotedEnrollmentId()).isEqualTo(777L);
+            assertThat(fullClass.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 선두_1명_skip_후_다음_승격() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            setField(fullClass, "enrolledCount", 0);
+
+            User skipUser = User.builder().name("skip").role(UserRole.CLASSMATE).build();
+            setId(skipUser, 3L);
+            User secondUser = User.builder().name("second").role(UserRole.CLASSMATE).build();
+            setId(secondUser, 4L);
+
+            Waitlist skipHead = Waitlist.builder()
+                    .classEntity(fullClass).user(skipUser)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(skipHead, 500L);
+            Waitlist secondHead = Waitlist.builder()
+                    .classEntity(fullClass).user(secondUser)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(secondHead, 501L);
+
+            given(waitlistRepository.findFirstWaitingForUpdate(10L))
+                    .willReturn(Optional.of(skipHead))
+                    .willReturn(Optional.of(secondHead));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 3L)).willReturn(true);
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 4L)).willReturn(false);
+            given(enrollmentRepository.save(any(Enrollment.class))).willAnswer(inv -> {
+                Enrollment e = inv.getArgument(0);
+                setId(e, 888L);
+                return e;
+            });
+
+            waitlistService.promoteNext(fullClass);
+
+            assertThat(skipHead.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(secondHead.getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+            assertThat(fullClass.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 선두_2명_연속_skip_후_3번째_승격() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            setField(fullClass, "enrolledCount", 0);
+
+            User a = User.builder().name("a").role(UserRole.CLASSMATE).build();
+            setId(a, 3L);
+            User b = User.builder().name("b").role(UserRole.CLASSMATE).build();
+            setId(b, 4L);
+            User c = User.builder().name("c").role(UserRole.CLASSMATE).build();
+            setId(c, 5L);
+
+            Waitlist wa = Waitlist.builder().classEntity(fullClass).user(a).status(WaitlistStatus.WAITING).build();
+            setId(wa, 500L);
+            Waitlist wb = Waitlist.builder().classEntity(fullClass).user(b).status(WaitlistStatus.WAITING).build();
+            setId(wb, 501L);
+            Waitlist wc = Waitlist.builder().classEntity(fullClass).user(c).status(WaitlistStatus.WAITING).build();
+            setId(wc, 502L);
+
+            given(waitlistRepository.findFirstWaitingForUpdate(10L))
+                    .willReturn(Optional.of(wa))
+                    .willReturn(Optional.of(wb))
+                    .willReturn(Optional.of(wc));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 3L)).willReturn(true);
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 4L)).willReturn(true);
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 5L)).willReturn(false);
+            given(enrollmentRepository.save(any(Enrollment.class))).willAnswer(inv -> {
+                Enrollment e = inv.getArgument(0);
+                setId(e, 999L);
+                return e;
+            });
+
+            waitlistService.promoteNext(fullClass);
+
+            assertThat(wa.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(wb.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(wc.getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+            assertThat(fullClass.getEnrolledCount()).isEqualTo(1);
+        }
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        setField(obj, "id", id);
+    }
+
+    private static void setField(Object obj, String name, Object value) throws Exception {
+        Class<?> clazz = obj.getClass();
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField(name);
+                field.setAccessible(true);
+                field.set(obj, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import com.enrollment.domain.classes.service.ClassService;
 import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.domain.waitlist.service.WaitlistService;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,6 +34,8 @@ class GlobalExceptionHandlerTest {
     ClassService classService;
     @MockBean
     EnrollmentService enrollmentService;
+    @MockBean
+    WaitlistService waitlistService;
 
     @Test
     void BusinessException_시_ErrorCode의_HttpStatus와_포맷으로_응답() throws Exception {


### PR DESCRIPTION
## Summary
- 정원 찬 강의에서 수강생이 대기열 등록 가능 (`POST /classes/{id}/waitlist`)
- 수강 취소 시 대기열 선두가 자동 PENDING 승격, 승격자는 결제만 하면 수강 확정
- 본인 대기열 철회 API 추가 (`DELETE /classes/{id}/waitlist/me`)
- 선두에게 이미 활성 수강 신청이 있으면 건너뛰고 다음 선두 승격
- 10개 스레드로 동시성 테스트, 좌석 증감 합계 0 검증

close #16

## 변경 사항

| 영역 | 파일 | 설명 |
|------|------|------|
| Domain | `Waitlist`, `WaitlistStatus` | 상태 머신(WAITING/PROMOTED/CANCELLED), promote/cancel/skip/validateOwner |
| Persistence | `WaitlistRepository`, `V6__create_waitlists_table.sql` | 부분 유니크 인덱스(`uk_active_waitlist`), 순번 인덱스(created_at + waitlist_id 타이브레이커), CHECK 제약 3종 |
| Service | `WaitlistService` | 등록/철회/선두 승격(promoteNext) |
| API | `WaitlistController` | POST/DELETE 2개 엔드포인트, Swagger |
| Service | `EnrollmentService.cancel()` | 말미에 `waitlistService.promoteNext(classEntity)` 호출 추가 |
| Domain | `ClassEntity.hasVacancy()` | 정원 여유 헬퍼 |
| Repository | `EnrollmentRepository.existsActiveByClassIdAndUserId` | default 메서드 |
| Error | `ErrorCode` 4종 | WAITLIST_NOT_ALLOWED, ALREADY_IN_WAITLIST, WAITLIST_NOT_FOUND, NOT_WAITLIST_OWNER |
| Docs | `README.md` | 프로젝트 개요 / API / 설계 결정 / 미구현 / 테스트 / AI 활용 정리 |

## 테스트 결과
- [x] `./gradlew clean test` 통과
- [x] BUILD SUCCESSFUL
- 전체 212 tests, 0 failures
- `WaitlistConcurrencyTest`
  - 정원 1 + 대기 3, 취소 시 정확히 1명 승격
  - 정원 10 + 대기 10, 2건 동시 취소 시 2명 PROMOTED + enrolledCount=10 유지
  - 다른 유저 5명 동시 register 성공

## 영향 범위
- 신규 엔드포인트 2개: `POST /classes/{id}/waitlist`, `DELETE /classes/{id}/waitlist/me`
- `EnrollmentService.cancel()` 한 줄 추가, 취소 직후 대기열 선두 자동 승격
- `ClassEntity`, `EnrollmentRepository`에 헬퍼 추가(기존 API 영향 없음)
- V6 마이그레이션 추가 (신규 waitlists 테이블)

## DB 마이그레이션

```sql
-- V6__create_waitlists_table.sql
CREATE TABLE waitlists (
    waitlist_id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
    class_id                BIGINT NOT NULL REFERENCES classes(class_id),
    user_id                 BIGINT NOT NULL REFERENCES users(user_id),
    status                  VARCHAR(20) NOT NULL,
    promoted_enrollment_id  BIGINT REFERENCES enrollments(enrollment_id),
    promoted_at             TIMESTAMP(6),
    cancelled_at            TIMESTAMP(6),
    created_at              TIMESTAMP(6) NOT NULL,
    updated_at              TIMESTAMP(6) NOT NULL,
    CONSTRAINT chk_waitlist_status CHECK (status IN ('WAITING', 'PROMOTED', 'CANCELLED')),
    CONSTRAINT chk_waitlist_promotion CHECK (
        (status = 'PROMOTED' AND promoted_enrollment_id IS NOT NULL AND promoted_at IS NOT NULL)
        OR (status <> 'PROMOTED')
    ),
    CONSTRAINT chk_waitlist_cancelled CHECK (
        (status = 'CANCELLED' AND cancelled_at IS NOT NULL)
        OR (status <> 'CANCELLED' AND cancelled_at IS NULL)
    )
);
CREATE INDEX idx_waitlists_class_id ON waitlists(class_id);
CREATE INDEX idx_waitlists_user_id ON waitlists(user_id);
CREATE UNIQUE INDEX uk_active_waitlist ON waitlists(class_id, user_id) WHERE status = 'WAITING';
CREATE INDEX idx_waitlist_fifo ON waitlists(class_id, created_at, waitlist_id) WHERE status = 'WAITING';
```

## 리뷰어 테스트

```bash
cd enrollment-infra && docker compose up -d
cd ../enrollment-api && ./gradlew bootRun

# 시나리오: 정원 1명 강의 → CONFIRMED 1명 → 대기열 1명 → 취소 → 자동 승격
CLASS_ID=$(curl -s -X POST http://localhost:8080/classes \
  -H "X-User-Id: 1" -H "Content-Type: application/json" \
  -d '{"title":"정원1","price":10000,"capacity":1,"startDate":"2026-06-01","endDate":"2026-06-30"}' | jq -r .classId)
curl -s -X PATCH http://localhost:8080/classes/$CLASS_ID/publish -H "X-User-Id: 1" | jq

# 수강생 2가 신청 + 결제 (정원 차지)
ENROLLMENT_ID=$(curl -s -X POST http://localhost:8080/enrollments \
  -H "X-User-Id: 2" -H "Content-Type: application/json" \
  -d "{\"classId\":$CLASS_ID}" | jq -r .enrollmentId)
curl -s -X PATCH http://localhost:8080/enrollments/$ENROLLMENT_ID/pay -H "X-User-Id: 2" | jq

# 수강생 3이 정원 초과 시도 (400)
curl -i -X POST http://localhost:8080/enrollments \
  -H "X-User-Id: 3" -H "Content-Type: application/json" \
  -d "{\"classId\":$CLASS_ID}"
# 400 CAPACITY_EXCEEDED

# 수강생 3이 대기열 등록
curl -s -X POST http://localhost:8080/classes/$CLASS_ID/waitlist -H "X-User-Id: 3" | jq

# 수강생 2가 취소, 수강생 3이 자동 PENDING 승격
curl -s -X PATCH http://localhost:8080/enrollments/$ENROLLMENT_ID/cancel -H "X-User-Id: 2" | jq

# 수강생 3의 수강 신청 목록에서 PENDING 확인
curl -s http://localhost:8080/enrollments/me -H "X-User-Id: 3" | jq
```
