### PR TITLE
[feat] PENDING TTL 만료 + 승격 알림 구현

### DIFF
--- a/enrollment-api/src/main/java/com/enrollment/EnrollmentApplication.java
+++ b/enrollment-api/src/main/java/com/enrollment/EnrollmentApplication.java
@@ -2,8 +2,10 @@ package com.enrollment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class EnrollmentApplication {
     public static void main(String[] args) {
         SpringApplication.run(EnrollmentApplication.class, args);

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
@@ -33,6 +33,9 @@ import java.time.LocalDateTime;
 public class Enrollment extends BaseEntity {
 
     private static final int CANCEL_WINDOW_DAYS = 7;
+    // 결제 가능 시간 30분: 카드 결제 평균 + 재로그인/카드 교체 여유.
+    // 운영 중 조정 빈도가 낮다고 판단해 상수로 유지. 필요 시 application.yml로 이동.
+    private static final int PENDING_TTL_MINUTES = 30;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -60,11 +63,18 @@ public class Enrollment extends BaseEntity {
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
 
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
     // 수강 신청 확정
     public void confirm() {
+        if (isExpired()) {
+            throw new BusinessException(ErrorCode.HOLD_EXPIRED);
+        }
         validateTransition(EnrollmentStatus.CONFIRMED);
         this.status = EnrollmentStatus.CONFIRMED;
         this.confirmedAt = LocalDateTime.now();
+        this.expiresAt = null;
     }
 
     // 수강 신청 취소
@@ -81,6 +91,24 @@ public class Enrollment extends BaseEntity {
         validateTransition(EnrollmentStatus.CANCELLED);
         this.status = EnrollmentStatus.CANCELLED;
         this.cancelledAt = LocalDateTime.now();
+    }
+
+    // PENDING TTL 만료 처리 (스케줄러 전용, 사용자 취소와 구분)
+    // - cancel()과 달리 상태 전이 검증 생략 (호출부에서 PENDING + 만료 확정)
+    // - 7일 기한 검증도 불필요 (만료 자체가 시스템 자동 종료)
+    public void expire() {
+        this.status = EnrollmentStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    // TTL 만료 여부 확인
+    public boolean isExpired() {
+        return this.expiresAt != null && this.expiresAt.isBefore(LocalDateTime.now());
+    }
+
+    // 신청 / 승격 시 공통 TTL 세팅
+    public static LocalDateTime defaultExpiresAt() {
+        return LocalDateTime.now().plusMinutes(PENDING_TTL_MINUTES);
     }
 
     // 수강 신청 소유자 검증

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -47,4 +48,12 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
         return existsByClassIdAndUserIdAndStatusIn(classId, userId,
                 List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED));
     }
+
+    // 만료된 PENDING 수강 신청 스캔 (오래 방치된 것부터 FIFO 처리)
+    @Query("SELECT e FROM Enrollment e JOIN FETCH e.classEntity "
+            + "WHERE e.status = :status AND e.expiresAt < :now "
+            + "ORDER BY e.expiresAt ASC")
+    List<Enrollment> findExpiredPendings(@Param("status") EnrollmentStatus status,
+                                         @Param("now") LocalDateTime now,
+                                         Pageable pageable);
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/scheduler/EnrollmentExpirationScheduler.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/scheduler/EnrollmentExpirationScheduler.java
@@ -1,0 +1,72 @@
+package com.enrollment.domain.enrollment.scheduler;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.waitlist.service.WaitlistService;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EnrollmentExpirationScheduler {
+
+    // 배치 크기 100 + 1분 주기 = 시간당 최대 6,000건 처리.
+    // 이보다 많은 만료율이 예상되면 BATCH_SIZE 상향 또는 다중 tick drain 방식으로 전환.
+    private static final int BATCH_SIZE = 100;
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final ClassRepository classRepository;
+    private final WaitlistService waitlistService;
+    private final TransactionTemplate transactionTemplate;
+
+    // 만료된 PENDING 스캔 (1분 주기)
+    @Scheduled(fixedDelay = 60_000)  // 1분 주기 — DB 부하/응답 지연 균형
+    public void expirePendings() {
+        List<Enrollment> expired = enrollmentRepository.findExpiredPendings(
+                EnrollmentStatus.PENDING, LocalDateTime.now(), PageRequest.of(0, BATCH_SIZE));
+        for (Enrollment e : expired) {
+            try {
+                transactionTemplate.executeWithoutResult(s -> expireOne(e.getId()));
+            } catch (Exception ex) {
+                // 한 건 실패가 전체 배치 중단을 막지 않음
+                log.warn("[Expire] Failed to expire enrollment={}", e.getId(), ex);
+            }
+        }
+    }
+
+    // 단건 만료 처리 (독립 트랜잭션)
+    public void expireOne(Long enrollmentId) {
+        Enrollment enrollment = enrollmentRepository.findByIdForUpdate(enrollmentId)
+                .orElse(null);
+        if (enrollment == null
+                || enrollment.getStatus() != EnrollmentStatus.PENDING
+                || !enrollment.isExpired()) {
+            return;
+        }
+        ClassEntity classEntity = classRepository.findByIdForUpdate(enrollment.getClassEntity().getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 만료 처리 + 좌석 복구
+        enrollment.expire();
+        classEntity.decrementEnrolled();
+
+        log.info("[Expire] enrollment={} user={} class={} expired, seat released",
+                enrollmentId, enrollment.getUser().getId(), classEntity.getId());
+
+        // 체인 승격
+        waitlistService.promoteNext(classEntity);
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -72,13 +72,14 @@ public class EnrollmentService {
                         .user(user)
                         .status(EnrollmentStatus.PENDING)
                         .enrolledAt(LocalDateTime.now())
+                        .expiresAt(Enrollment.defaultExpiresAt())
                         .build()));
     }
 
     // 결제
     @Transactional
     public EnrollmentResponse pay(Long userId, Long enrollmentId) {
-        
+
         // 수강 신청 조회 (본인 row 상태 변경만이라 락 불필요, 상태머신 + uk_payment_paid 부분 유니크 인덱스로 방어)
         Enrollment enrollment = enrollmentRepository.findWithClassAndUserById(enrollmentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -80,8 +80,8 @@ public class EnrollmentService {
     @Transactional
     public EnrollmentResponse pay(Long userId, Long enrollmentId) {
 
-        // 수강 신청 조회 (본인 row 상태 변경만이라 락 불필요, 상태머신 + uk_payment_paid 부분 유니크 인덱스로 방어)
-        Enrollment enrollment = enrollmentRepository.findWithClassAndUserById(enrollmentId)
+        // 수강 신청 조회 (만료 스케줄러와의 race 방지 위해 비관적 락으로 직렬화)
+        Enrollment enrollment = enrollmentRepository.findByIdForUpdate(enrollmentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
 
         // 수강 신청 소유자 검증

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/service/WaitlistService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/service/WaitlistService.java
@@ -15,12 +15,14 @@ import com.enrollment.domain.waitlist.repository.WaitlistRepository;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -117,10 +119,15 @@ public class WaitlistService {
                             .user(next.getUser())
                             .status(EnrollmentStatus.PENDING)
                             .enrolledAt(LocalDateTime.now())
+                            .expiresAt(Enrollment.defaultExpiresAt())
                             .build());
 
             // 대기열 승격
             next.promote(promoted.getId());
+
+            // 승격 알림 로그
+            log.info("[Waitlist] Promoted user={} to enrollment={} (expiresAt={})",
+                    next.getUser().getId(), promoted.getId(), promoted.getExpiresAt());
             break;
         }
     }

--- a/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "ALREADY_CANCELLED", "이미 취소된 수강 신청입니다"),
     INVALID_STATE_TRANSITION(HttpStatus.BAD_REQUEST, "INVALID_STATE_TRANSITION", "허용되지 않은 상태 전이입니다"),
     WAITLIST_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "WAITLIST_NOT_ALLOWED", "대기열에 등록할 수 없습니다"),
+    HOLD_EXPIRED(HttpStatus.BAD_REQUEST, "HOLD_EXPIRED", "결제 가능 시간이 초과되었습니다"),
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다"),
 

--- a/enrollment-api/src/main/resources/db/migration/V7__add_enrollment_expires_at.sql
+++ b/enrollment-api/src/main/resources/db/migration/V7__add_enrollment_expires_at.sql
@@ -1,0 +1,5 @@
+ALTER TABLE enrollments ADD COLUMN expires_at TIMESTAMP(6);
+
+CREATE INDEX idx_enrollments_pending_expires
+    ON enrollments(expires_at)
+    WHERE status = 'PENDING';

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentTest.java
@@ -90,6 +90,88 @@ class EnrollmentTest {
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
         }
+
+        @Test
+        void 만료_이전_confirm_성공_후_expiresAt_null() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            setField(enrollment, "expiresAt", LocalDateTime.now().plusMinutes(10));
+
+            enrollment.confirm();
+
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+            assertThat(enrollment.getExpiresAt()).isNull();
+        }
+
+        @Test
+        void 만료_이후_confirm_시_HOLD_EXPIRED() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            setField(enrollment, "expiresAt", LocalDateTime.now().minusSeconds(1));
+
+            assertThatThrownBy(enrollment::confirm)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.HOLD_EXPIRED));
+        }
+    }
+
+    @Nested
+    class Expire {
+
+        @Test
+        void PENDING에서_expire_시_CANCELLED_및_cancelledAt_세팅() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+
+            enrollment.expire();
+
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+            assertThat(enrollment.getCancelledAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class IsExpired {
+
+        @Test
+        void expiresAt_null_이면_false() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            assertThat(enrollment.isExpired()).isFalse();
+        }
+
+        @Test
+        void 정확히_30분_이전_expiresAt이면_false() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            // 30분 - 1초 (아직 유효)
+            setField(enrollment, "expiresAt", LocalDateTime.now().plusMinutes(29).plusSeconds(59));
+            assertThat(enrollment.isExpired()).isFalse();
+        }
+
+        @Test
+        void 과거_expiresAt이면_true() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            setField(enrollment, "expiresAt", LocalDateTime.now().minusSeconds(1));
+            assertThat(enrollment.isExpired()).isTrue();
+        }
+
+        @Test
+        void 미래_expiresAt이면_false() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            setField(enrollment, "expiresAt", LocalDateTime.now().plusMinutes(30).plusSeconds(1));
+            assertThat(enrollment.isExpired()).isFalse();
+        }
+    }
+
+    @Nested
+    class DefaultExpiresAt {
+
+        @Test
+        void defaultExpiresAt은_현재시각_30분_후() {
+            LocalDateTime before = LocalDateTime.now().plusMinutes(30).minusSeconds(1);
+            LocalDateTime value = Enrollment.defaultExpiresAt();
+            LocalDateTime after = LocalDateTime.now().plusMinutes(30).plusSeconds(1);
+
+            assertThat(value).isAfter(before);
+            assertThat(value).isBefore(after);
+        }
     }
 
     @Nested

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/repository/EnrollmentRepositoryTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/repository/EnrollmentRepositoryTest.java
@@ -157,12 +157,79 @@ class EnrollmentRepositoryTest extends AbstractIntegrationTest {
         assertThat(saved.getId()).isNotNull();
     }
 
+    @Test
+    void findExpiredPendings_PENDING_만료된_것만_반환() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 만료된 PENDING
+        User expiredUser = userRepository.saveAndFlush(
+                User.builder().name("expiredStudent").role(UserRole.CLASSMATE).build());
+        Enrollment expired = enrollmentRepository.saveAndFlush(
+                pendingEnrollmentWithExpiresAt(openClass, expiredUser, now.minusMinutes(1)));
+
+        // 아직 만료 안 된 PENDING
+        User freshUser = userRepository.saveAndFlush(
+                User.builder().name("freshStudent").role(UserRole.CLASSMATE).build());
+        enrollmentRepository.saveAndFlush(
+                pendingEnrollmentWithExpiresAt(openClass, freshUser, now.plusMinutes(10)));
+
+        // CONFIRMED (만료 컬럼 무관)
+        User confirmedUser = userRepository.saveAndFlush(
+                User.builder().name("confirmedStudent").role(UserRole.CLASSMATE).build());
+        Enrollment confirmed = newEnrollment(openClass, confirmedUser);
+        confirmed.confirm();
+        enrollmentRepository.saveAndFlush(confirmed);
+
+        // CANCELLED
+        User cancelledUser = userRepository.saveAndFlush(
+                User.builder().name("cancelledStudent").role(UserRole.CLASSMATE).build());
+        Enrollment cancelled = newEnrollment(openClass, cancelledUser);
+        cancelled.cancel();
+        enrollmentRepository.saveAndFlush(cancelled);
+
+        em.clear();
+
+        List<Enrollment> result = enrollmentRepository.findExpiredPendings(
+                EnrollmentStatus.PENDING, now, PageRequest.of(0, 100));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(expired.getId());
+    }
+
+    @Test
+    void findExpiredPendings_LIMIT_적용() {
+        LocalDateTime now = LocalDateTime.now();
+        for (int i = 0; i < 5; i++) {
+            User u = userRepository.saveAndFlush(
+                    User.builder().name("student" + i).role(UserRole.CLASSMATE).build());
+            enrollmentRepository.saveAndFlush(
+                    pendingEnrollmentWithExpiresAt(openClass, u, now.minusMinutes(1)));
+        }
+        em.clear();
+
+        List<Enrollment> result = enrollmentRepository.findExpiredPendings(
+                EnrollmentStatus.PENDING, now, PageRequest.of(0, 2));
+
+        assertThat(result).hasSize(2);
+    }
+
     private Enrollment newEnrollment(ClassEntity classEntity, User user) {
         return Enrollment.builder()
                 .classEntity(classEntity)
                 .user(user)
                 .status(EnrollmentStatus.PENDING)
                 .enrolledAt(LocalDateTime.now())
+                .build();
+    }
+
+    private Enrollment pendingEnrollmentWithExpiresAt(
+            ClassEntity classEntity, User user, LocalDateTime expiresAt) {
+        return Enrollment.builder()
+                .classEntity(classEntity)
+                .user(user)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .expiresAt(expiresAt)
                 .build();
     }
 }

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/scheduler/EnrollmentExpirationSchedulerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/scheduler/EnrollmentExpirationSchedulerTest.java
@@ -1,0 +1,184 @@
+package com.enrollment.domain.enrollment.scheduler;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.domain.waitlist.repository.WaitlistRepository;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class EnrollmentExpirationSchedulerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    EnrollmentExpirationScheduler scheduler;
+    @Autowired
+    EnrollmentRepository enrollmentRepository;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    WaitlistRepository waitlistRepository;
+    @Autowired
+    TransactionTemplate transactionTemplate;
+
+    private User creator;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build());
+    }
+
+    @Test
+    void 만료된_PENDING_실행_시_CANCELLED_및_enrolledCount_감소() {
+        User classmate = userRepository.saveAndFlush(
+                User.builder().name("student").role(UserRole.CLASSMATE).build());
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("Java 기초").description("설명")
+                        .price(10000).capacity(10).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+
+        // 만료된 PENDING 생성
+        Enrollment saved = transactionTemplate.execute(s ->
+                enrollmentRepository.saveAndFlush(
+                        Enrollment.builder()
+                                .classEntity(classRepository.findById(openClass.getId()).orElseThrow())
+                                .user(userRepository.findById(classmate.getId()).orElseThrow())
+                                .status(EnrollmentStatus.PENDING)
+                                .enrolledAt(LocalDateTime.now().minusMinutes(31))
+                                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                                .build()));
+
+        // 만료 스캔 수동 실행
+        scheduler.expirePendings();
+
+        Enrollment result = enrollmentRepository.findById(saved.getId()).orElseThrow();
+        assertThat(result.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(result.getCancelledAt()).isNotNull();
+
+        ClassEntity updatedClass = classRepository.findById(openClass.getId()).orElseThrow();
+        assertThat(updatedClass.getEnrolledCount()).isEqualTo(0);
+    }
+
+    @Test
+    void 만료_이후_대기자_있으면_체인_승격() {
+        User pendingUser = userRepository.saveAndFlush(
+                User.builder().name("pending").role(UserRole.CLASSMATE).build());
+        User waitingUser = userRepository.saveAndFlush(
+                User.builder().name("waiting").role(UserRole.CLASSMATE).build());
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("인기_강의").description("정원 1")
+                        .price(10000).capacity(1).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+
+        // 만료된 PENDING + WAITING 1명 사전 세팅
+        Enrollment expired = transactionTemplate.execute(s ->
+                enrollmentRepository.saveAndFlush(
+                        Enrollment.builder()
+                                .classEntity(classRepository.findById(openClass.getId()).orElseThrow())
+                                .user(userRepository.findById(pendingUser.getId()).orElseThrow())
+                                .status(EnrollmentStatus.PENDING)
+                                .enrolledAt(LocalDateTime.now().minusMinutes(31))
+                                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                                .build()));
+
+        transactionTemplate.executeWithoutResult(s ->
+                waitlistRepository.saveAndFlush(
+                        Waitlist.builder()
+                                .classEntity(classRepository.findById(openClass.getId()).orElseThrow())
+                                .user(userRepository.findById(waitingUser.getId()).orElseThrow())
+                                .status(WaitlistStatus.WAITING)
+                                .build()));
+
+        // 만료 스캔 실행
+        scheduler.expirePendings();
+
+        // 기존 PENDING → CANCELLED
+        Enrollment expiredResult = enrollmentRepository.findById(expired.getId()).orElseThrow();
+        assertThat(expiredResult.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+
+        // 대기자 승격 확인
+        List<Waitlist> waitlists = waitlistRepository.findAll().stream()
+                .filter(w -> w.getClassEntity().getId().equals(openClass.getId()))
+                .toList();
+        assertThat(waitlists).hasSize(1);
+        assertThat(waitlists.get(0).getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+
+        // 새 PENDING + expiresAt 세팅 확인
+        List<Enrollment> pendings = enrollmentRepository.findAll().stream()
+                .filter(e -> e.getClassEntity().getId().equals(openClass.getId())
+                        && e.getStatus() == EnrollmentStatus.PENDING)
+                .toList();
+        assertThat(pendings).hasSize(1);
+        assertThat(pendings.get(0).getUser().getId()).isEqualTo(waitingUser.getId());
+        assertThat(pendings.get(0).getExpiresAt()).isNotNull();
+        assertThat(pendings.get(0).getExpiresAt()).isAfter(LocalDateTime.now().plusMinutes(29));
+
+        // 좌석 유지 (만료 -1, 승격 +1 = net 0)
+        ClassEntity updatedClass = classRepository.findById(openClass.getId()).orElseThrow();
+        assertThat(updatedClass.getEnrolledCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 대기자_없으면_좌석만_해제() {
+        User classmate = userRepository.saveAndFlush(
+                User.builder().name("only").role(UserRole.CLASSMATE).build());
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("여유_강의").description("정원 10")
+                        .price(10000).capacity(10).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+
+        transactionTemplate.executeWithoutResult(s ->
+                enrollmentRepository.saveAndFlush(
+                        Enrollment.builder()
+                                .classEntity(classRepository.findById(openClass.getId()).orElseThrow())
+                                .user(userRepository.findById(classmate.getId()).orElseThrow())
+                                .status(EnrollmentStatus.PENDING)
+                                .enrolledAt(LocalDateTime.now().minusMinutes(31))
+                                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                                .build()));
+
+        scheduler.expirePendings();
+
+        ClassEntity updatedClass = classRepository.findById(openClass.getId()).orElseThrow();
+        assertThat(updatedClass.getEnrolledCount()).isEqualTo(0);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
@@ -205,7 +205,7 @@ class EnrollmentServiceTest {
         void 정상_결제() throws Exception {
             ClassEntity openClass = openClass(30, 1);
             Enrollment enrollment = pendingEnrollment(openClass);
-            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
 
             ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
             given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
@@ -223,7 +223,7 @@ class EnrollmentServiceTest {
 
         @Test
         void 신청_미존재_시_ENROLLMENT_NOT_FOUND() {
-            given(enrollmentRepository.findWithClassAndUserById(999L)).willReturn(Optional.empty());
+            given(enrollmentRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> enrollmentService.pay(2L, 999L))
                     .isInstanceOf(BusinessException.class)
@@ -235,7 +235,7 @@ class EnrollmentServiceTest {
         void 소유자_불일치_시_NOT_ENROLLMENT_OWNER() throws Exception {
             ClassEntity openClass = openClass(30, 1);
             Enrollment enrollment = pendingEnrollment(openClass);
-            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
 
             assertThatThrownBy(() -> enrollmentService.pay(999L, 100L))
                     .isInstanceOf(BusinessException.class)
@@ -248,12 +248,25 @@ class EnrollmentServiceTest {
             ClassEntity openClass = openClass(30, 1);
             Enrollment enrollment = pendingEnrollment(openClass);
             enrollment.confirm();
-            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
 
             assertThatThrownBy(() -> enrollmentService.pay(2L, 100L))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void 만료된_PENDING_결제_시_HOLD_EXPIRED() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            setField(enrollment, "expiresAt", LocalDateTime.now().minusMinutes(1));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+
+            assertThatThrownBy(() -> enrollmentService.pay(2L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.HOLD_EXPIRED));
         }
     }
 


### PR DESCRIPTION
## Summary
- PENDING 수강 신청 30분 TTL 도입, 결제 없으면 스케줄러가 자동 취소 + 좌석 복구
- 1분 주기 배치(`@Scheduled(fixedDelay = 60_000)`)로 만료 PENDING을 들어온 순서대로 처리
- 만료 취소 시 `waitlistService.promoteNext()`로 다음 대기자 자동 승격
- `EnrollmentService.pay()` 비관적 락 재도입, 스케줄러와 같은 행을 직렬화해 경쟁 조건 차단
- 대기열 선두 승격 시점 INFO 로그 기록

close #18

## 변경 사항

| 영역 | 파일 | 설명 |
|------|------|------|
| Migration | `V7__add_enrollment_expires_at.sql` | `enrollments.expires_at` 컬럼, 부분 인덱스(`WHERE status='PENDING'`) |
| Domain | `Enrollment` | `expiresAt` 필드, `expire()` / `isExpired()` / `defaultExpiresAt()`, `confirm()`에 만료 검증 |
| Repository | `EnrollmentRepository.findExpiredPendings` | 만료된 PENDING을 오래된 순으로 조회, JOIN FETCH로 classEntity 동시 로드 |
| Scheduler | `EnrollmentExpirationScheduler` | 1분 주기, 배치 100건, TransactionTemplate으로 행 단위 트랜잭션 분리 |
| Service | `EnrollmentService.enroll()` / `pay()` | enroll: TTL 세팅 / pay: `findByIdForUpdate`로 복원(경쟁 조건 차단) |
| Service | `WaitlistService.promoteNext()` | 승격 enrollment TTL 세팅, INFO 로그 추가 |
| Bootstrap | `EnrollmentApplication` | `@EnableScheduling` |
| Error | `ErrorCode.HOLD_EXPIRED` | 400, 만료 후 결제 시도 응답 |

## 테스트 결과
- [x] `./gradlew clean test` 통과
- [x] BUILD SUCCESSFUL
- 전체 226 tests, 0 failures
- `EnrollmentTest`: expiresAt 세팅, isExpired 경계값, 만료 후 confirm 시 HOLD_EXPIRED, expire 전이
- `EnrollmentRepositoryTest`: findExpiredPendings 오래된 순 정렬, PENDING 상태 필터
- `EnrollmentExpirationSchedulerTest`: Testcontainers 통합, 만료 PENDING이 CANCELLED + 좌석 복구 + 대기열 연쇄 승격
- `EnrollmentServiceTest`: 만료된 PENDING 결제 시 HOLD_EXPIRED 응답

## 영향 범위
- `EnrollmentService.enroll()` / `WaitlistService.promoteNext()`: PENDING 생성 경로 모두 TTL 세팅
- `EnrollmentService.pay()`: `findWithClassAndUserById` → `findByIdForUpdate` (락 재도입, 응답 시간 영향 미미)
- `@EnableScheduling` 활성화로 1분 주기 배치 스케줄러 추가
- V7 마이그레이션 추가

## DB 마이그레이션

```sql
-- V7__add_enrollment_expires_at.sql
ALTER TABLE enrollments ADD COLUMN expires_at TIMESTAMP(6);
CREATE INDEX idx_enrollments_pending_expires
    ON enrollments(expires_at)
    WHERE status = 'PENDING';
```

> prod 환경(`ddl-auto: validate`) 반영을 위해 운영 DB에도 위 SQL 선반영 필요.
