### PR TITLE
Release: 수강 신청 시스템 전체 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ HELP.md
 .omc
 
 todo.md
+기획서.md
+docs/

--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 온라인 라이브 클래스의 수강 신청 시스템 백엔드 API.
 
-> 과제 제출용 프로젝트
-
 ## 프로젝트 개요
 
-_(추후 작성)_
+크리에이터(강사)가 강의를 개설하고, 클래스메이트(수강생)가 신청·결제·취소하는 전 과정을 처리한다.
+
+**핵심 비즈니스 규칙**
+- 강의 상태 머신: `DRAFT → OPEN → CLOSED`
+- 수강 신청 상태 머신: `PENDING → CONFIRMED → CANCELLED`
+- 정원 초과 시 신청 거부, 동시 신청은 비관적 락으로 직렬화
+- CONFIRMED 이후 7일 이내에만 수강 취소 가능 (환불 이력 기록)
+- 정원이 찬 강의에는 대기열 등록 가능, 취소 발생 시 선두 자동 승격
 
 ## 기술 스택
 
@@ -17,14 +22,16 @@ _(추후 작성)_
 - Gradle
 - Docker / Docker Compose
 - Swagger UI (springdoc-openapi)
+- Testcontainers (JUnit 통합 테스트)
 
 ## 실행 방법
 
 ### 로컬
+
 ```bash
 # 1. DB 기동
 cd enrollment-infra
-docker-compose up -d
+docker compose up -d
 
 # 2. 앱 실행
 cd ../enrollment-api
@@ -38,30 +45,229 @@ curl http://localhost:8080/actuator/health
 open http://localhost:8080/swagger-ui/index.html
 ```
 
+### 시드 유저 (V3 마이그레이션)
+
+앱 기동 시 Flyway가 자동으로 시드 유저 2명을 생성한다.
+
+| user_id | role | 설명 |
+|---------|------|------|
+| 1 | CREATOR | 강사용 |
+| 2 | CLASSMATE | 수강생용 |
+
+`X-User-Id` 헤더로 식별하므로 리뷰 시 별도 가입 과정 없이 바로 API 호출 가능.
+
 ## API 목록 및 예시
 
-_(추후 작성)_
+### 강의 관리
+
+| # | Method | Path | 권한 |
+|---|--------|------|------|
+| 1 | POST | `/classes` | 강사 |
+| 2 | PATCH | `/classes/{id}` | 본인 강사 |
+| 3 | PATCH | `/classes/{id}/publish` | 본인 강사 |
+| 4 | PATCH | `/classes/{id}/close` | 본인 강사 |
+| 5 | GET | `/classes?status=OPEN&page=0&size=20` | 누구나 |
+| 6 | GET | `/classes/{id}` | 누구나 |
+| 7 | GET | `/classes/me?page=0&size=20` | 강사 |
+| 8 | GET | `/classes/{id}/enrollments?page=0&size=20` | 본인 강사 |
+
+### 수강 신청 / 결제 / 취소
+
+| # | Method | Path | 권한 |
+|---|--------|------|------|
+| 9 | POST | `/enrollments` | 수강생 |
+| 10 | PATCH | `/enrollments/{id}/pay` | 본인 수강생 |
+| 11 | PATCH | `/enrollments/{id}/cancel` | 본인 수강생 |
+| 12 | GET | `/enrollments/me?page=0&size=20` | 수강생 |
+
+### 대기열 (정원 초과 시)
+
+| # | Method | Path | 권한 |
+|---|--------|------|------|
+| 13 | POST | `/classes/{id}/waitlist` | 수강생 |
+| 14 | DELETE | `/classes/{id}/waitlist/me` | 본인 |
+
+### 요청 예시
+
+```bash
+# 강의 등록 (CREATOR)
+curl -X POST http://localhost:8080/classes \
+  -H "X-User-Id: 1" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Java 기초",
+    "description": "자바 입문 강의",
+    "price": 50000,
+    "capacity": 10,
+    "startDate": "2026-06-01",
+    "endDate": "2026-06-30"
+  }'
+
+# 강의 공개
+curl -X PATCH http://localhost:8080/classes/1/publish -H "X-User-Id: 1"
+
+# 수강 신청 (CLASSMATE)
+curl -X POST http://localhost:8080/enrollments \
+  -H "X-User-Id: 2" \
+  -H "Content-Type: application/json" \
+  -d '{"classId": 1}'
+
+# 결제
+curl -X PATCH http://localhost:8080/enrollments/1/pay -H "X-User-Id: 2"
+
+# 취소
+curl -X PATCH http://localhost:8080/enrollments/1/cancel -H "X-User-Id: 2"
+
+# 대기열 등록 (정원 초과 시)
+curl -X POST http://localhost:8080/classes/1/waitlist -H "X-User-Id: 3"
+```
+
+### 에러 응답 포맷
+
+```json
+{
+  "code": "CAPACITY_EXCEEDED",
+  "message": "정원이 초과되었습니다",
+  "timestamp": "2026-04-19T14:00:00",
+  "path": "/enrollments"
+}
+```
 
 ## 데이터 모델 설명
 
-_(추후 작성)_
+### 테이블
+
+| 테이블 | 책임 |
+|--------|------|
+| `users` | 사용자 식별 + 역할 구분 (CREATOR / CLASSMATE) |
+| `classes` | 강의 정보 + 현재 신청 수(`enrolled_count`, 역정규화 + 락 대상) |
+| `enrollments` | 수강 신청 이력 + 상태 (PENDING / CONFIRMED / CANCELLED) |
+| `payments` | 결제 이력 (append-only, PAID / REFUNDED / FAILED) |
+| `waitlists` | 대기열 (WAITING / PROMOTED / CANCELLED) |
+
+### 연관 관계 (모두 단방향 `@ManyToOne`)
+
+- User → Class(`created_by` FK) : 강사가 여러 강의를 개설
+- User → Enrollment(`user_id` FK) : 수강생이 여러 신청
+- Class → Enrollment(`class_id` FK)
+- Enrollment → Payment(`enrollment_id` FK)
+- Class → Waitlist, User → Waitlist
+- Waitlist → Enrollment(`promoted_enrollment_id` FK, 승격 시에만)
+
+양방향 매핑은 JSON 순환 참조 + N+1 위험이 커서 역참조는 모두 Repository 쿼리로 명시적 처리.
+
+### 상태 머신
+
+```
+Class:       DRAFT  ──publish──▶  OPEN  ──close──▶  CLOSED
+Enrollment:  PENDING ──pay──▶ CONFIRMED ──cancel(7일 이내)──▶ CANCELLED
+                │                                                ▲
+                └──────cancel(결제 전 자유)──────────────────────┘
+Waitlist:    WAITING ──promote──▶ PROMOTED (terminal)
+                │
+                └──cancel──▶ CANCELLED (terminal, 재등록은 새 row)
+Payment:     append-only (상태 전이 없음, 각 row 독립)
+```
 
 ## 요구사항 해석 및 가정
 
-_(추후 작성)_
+1. **인증은 X-User-Id 헤더로 단순화**. Spring Security / JWT는 범위 밖. 실서비스에선 게이트웨이에서 주입되는 구조를 가정
+2. **좌석 차감 시점**: 수강 신청(PENDING 생성) 시점. 결제 이전이라도 좌석을 즉시 점유(홀드)하여 "결제 완료 후 좌석 없음" 상황 방지
+3. **결제 시뮬레이션**: 외부 PG 연동 없이 `PATCH /enrollments/{id}/pay` 호출 시 즉시 `PAID` row를 INSERT. `pg_transaction_id`, 콜백 등은 미구현
+4. **취소 가능 기간**: CONFIRMED 이후 7일을 상수로 박음. 강의별 정책은 추후 `ClassEntity`로 이동 가능
+5. **사용자 역할**: 한 User가 CREATOR 겸 CLASSMATE일 수 있음. `role` 컬럼은 힌트이고 실제 권한은 리소스 소유권(FK) 기반 판단
+6. **강사 본인 강의 수강**: 허용. 요구사항에 금지 조항 없음
+7. **수강 취소 후 재신청**: 허용. 중복 신청 방지 인덱스는 활성 상태(`PENDING`, `CONFIRMED`)에만 적용
+8. **환불 처리**: CONFIRMED 상태에서 취소 시 `payments` 테이블에 `REFUNDED` row 자동 INSERT. 실제 금전 환불은 PG 영역이라 이력만 기록
+9. **DELETE 메서드 부재**: 모든 삭제는 상태 전이로 대체하여 이력 보존
 
 ## 설계 결정과 이유
 
-_(추후 작성)_
+### 1. 좌석 차감 타이밍 — 신청 시점(PENDING)
+- 결제 시점 차감이면 "결제 완료 후 좌석 없음" 경쟁이 발생
+- 여러 사용자가 PENDING 상태에서 동시 결제 시도 시 한 명만 성공, 나머지는 환불 지옥
+- 동시성 제어 지점을 **신청 API 1곳**으로 단일화
+
+### 2. 동시성 제어 — 비관적 락 `SELECT ... FOR UPDATE`
+- 인기 강의는 충돌 빈도가 높아 낙관적 락(`@Version`)은 재시도 비용 큼
+- `classes` row 단일 락으로 신청/취소/대기 승격 전부 직렬화
+- 10-스레드 동시 신청 시나리오 테스트(`EnrollmentConcurrencyTest`, `WaitlistConcurrencyTest`)로 검증
+
+### 3. 역정규화 — `classes.enrolled_count`
+- 강의 목록 조회 시 매번 `SELECT COUNT(*) FROM enrollments`는 N+1
+- `enrolled_count` 컬럼 유지 + `CHECK (enrolled_count <= capacity)` DB 레벨 불변식
+- 3중 방어: 서비스 체크 + 엔티티 도메인 메서드 + DB CHECK
+
+### 4. 중복 신청 방지 — PostgreSQL 부분 유니크 인덱스
+```sql
+CREATE UNIQUE INDEX uk_active_enrollment
+    ON enrollments(class_id, user_id)
+    WHERE status IN ('PENDING', 'CONFIRMED');
+```
+- 취소 후 재신청은 허용(CANCELLED는 인덱스 밖), 동일 강의 중복 활성 신청은 차단
+- MySQL이었다면 Generated Column 우회 필요 — PostgreSQL 선택으로 스키마 단순화
+
+### 5. 결제는 append-only
+- `payments.status`는 전이 없이 새 row INSERT
+- 결제 완료: `PAID` INSERT, 환불: `REFUNDED` INSERT, 실패: `FAILED` INSERT (현재 미구현)
+- `uk_payment_paid WHERE status='PAID'` 부분 유니크 인덱스로 이중 결제 DB 차단
+- 감사(audit)/환불 추적이 쉬움
+
+### 6. 대기열 — 수동 등록 + 자동 승격
+- 정원 초과 응답(`CAPACITY_EXCEEDED`) 받은 클라이언트가 명시적으로 `POST /classes/{id}/waitlist` 호출 (자동 대기 안 함)
+- 수강 취소 발생 시 `EnrollmentService.cancel()` 말미에서 `WaitlistService.promoteNext()` 동기 호출 → 선두 자동 승격
+- 선두가 이미 다른 경로로 활성 신청을 가지고 있으면 `skip` 후 다음 선두로 (방어 while 루프)
+- 자동 승격 시 `Enrollment`는 `PENDING` 상태로 생성되어 승격자가 결제만 하면 수강 확정
+
+### 7. 역할(Role) 검증 — 강의 등록에만 적용
+- `POST /classes`는 `CREATOR` 역할만 허용 (`FORBIDDEN_ROLE`)
+- 수정/공개/마감/수강생 목록 조회는 "본인 강의"(소유권) 검증만으로 충분
+- 한 User가 CREATOR + CLASSMATE 모두 가능 (기획 가정)
 
 ## 테스트 실행 방법
 
-_(추후 작성)_
+```bash
+cd enrollment-api
+
+# 전체 테스트
+./gradlew test
+
+# 커버리지 리포트 (JaCoCo)
+./gradlew test jacocoTestReport
+open build/reports/jacoco/test/html/index.html
+```
+
+### 테스트 구성 (총 212 tests)
+
+| 계층 | 프레임워크 | 주요 대상 |
+|------|----------|---------|
+| Entity 단위 | JUnit 5 | 상태 머신, 도메인 메서드 검증 |
+| Service 단위 | Mockito | 비즈니스 로직, 에러 경로 |
+| Repository 통합 | `@DataJpaTest` + Testcontainers PostgreSQL | CHECK 제약, 부분 유니크 인덱스, JOIN FETCH |
+| Controller 슬라이스 | `@WebMvcTest` + `@Import(GlobalExceptionHandler)` | HTTP 상태 / 에러 코드 매핑 |
+| 동시성 통합 | `@SpringBootTest` + Testcontainers | 10-스레드 정원 경쟁, net-zero 불변식 |
+
+Testcontainers가 Docker 컨테이너로 실제 PostgreSQL 15를 띄워 Flyway 마이그레이션(V1~V6)까지 실행하므로 프로덕션과 동일한 환경에서 검증.
 
 ## 미구현 / 제약사항
 
-_(추후 작성)_
+| 항목 | 이유 / 확장 방향 |
+|------|----------------|
+| **인증/인가 체계** | `X-User-Id` 헤더 신뢰. 실제 환경에선 Spring Security + JWT/게이트웨이로 대체 |
+| **PG 실제 연동** | 외부 결제 시스템 범위 밖. `PAID` 상태 단순 기록. 확장 시 `PENDING_APPROVAL` 중간 상태 + 콜백 핸들러 + `pg_transaction_id` 컬럼 추가 |
+| **PENDING TTL** | 결제 지연 시 좌석이 무한 홀드. 확장 시 `expires_at` 컬럼 + `@Scheduled` 1분 배치로 만료 CANCELLED + 다음 대기자 자동 승격 체인 |
+| **대기열 승격 알림** | 이메일/푸시/WebSocket 등 통신 레이어는 범위 밖. 승격자는 `/enrollments/me` 조회로 PENDING 확인 후 결제 |
+| **대기 순번 조회 API** | MVP에서 제외. 필요 시 `ROW_NUMBER() OVER` 기반 별도 엔드포인트 추가 |
+| **다중 서버 확장** | 단일 인스턴스 기준 비관적 락. 수평 확장 시 Redis 분산락(Redisson) 추가 필요 |
+| **강의 기간 종료 자동 마감** | `end_date` 경과 시 자동 CLOSED 전환 미구현. `@Scheduled` 자정 배치로 확장 가능 |
+| **DRAFT 강의 삭제** | 물리 삭제 미지원. 현재 정책상 모든 삭제는 상태 전이(CANCELLED / CLOSED)로 대체 |
 
 ## AI 활용 범위
 
-_(추후 작성)_
+- **코드 생성**: Spring Boot 기본 구조, Repository/Service/Controller 레이어 보일러플레이트를 Claude Code CLI(Sonnet 4.6 / Opus 4.7)로 초안 생성 후 수정·검토
+- **설계 검토**: 동시성 락 전략, 역정규화 구조, 부분 유니크 인덱스 사용 여부 등 의사결정 전에 AI와 trade-off 대화로 검증
+- **테스트 시나리오 발굴**: 엣지 케이스(7일 경계값, 10-스레드 경쟁, 부분 유니크 인덱스 양방향) 후보 제안 및 리뷰
+- **문서 정리**: README / 커밋 메시지 초안
+- **제외**: 비즈니스 요구사항 해석과 최종 설계 결정은 직접 수행. AI 출력은 전부 수동 검토 후 반영
+
+주요 프롬프트 패턴은 "X 대신 Y로 바꾸면 어떤 trade-off가 있나?", "이 코드에서 실무적으로 지적될 수 있는 부분은?" 같은 **비판/검토 질문**. 코드를 그대로 쓰지 않고 프로젝트 컨벤션에 맞게 재작성.

--- a/enrollment-api/build.gradle
+++ b/enrollment-api/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:junit-jupiter'
     testRuntimeOnly    'org.junit.platform:junit-platform-launcher'
 }
 

--- a/enrollment-api/src/main/java/com/enrollment/EnrollmentApplication.java
+++ b/enrollment-api/src/main/java/com/enrollment/EnrollmentApplication.java
@@ -2,8 +2,10 @@ package com.enrollment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class EnrollmentApplication {
     public static void main(String[] args) {
         SpringApplication.run(EnrollmentApplication.class, args);

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
@@ -2,6 +2,7 @@ package com.enrollment.domain.classes.controller;
 
 import com.enrollment.domain.classes.dto.ClassCreateRequest;
 import com.enrollment.domain.classes.dto.ClassResponse;
+import com.enrollment.domain.classes.dto.ClassUpdateRequest;
 import com.enrollment.domain.classes.service.ClassService;
 import com.enrollment.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -48,5 +51,72 @@ public class ClassController {
             @RequestHeader("X-User-Id") Long userId,
             @RequestBody @Valid ClassCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(classService.create(userId, request));
+    }
+
+    @Operation(summary = "강의 수정", description = "기존 강의 정보를 수정합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "강의 수정 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ClassResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 상태 전환 또는 입력값 (INVALID_STATE_TRANSITION, INVALID_INPUT)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "강의 소유자가 아님 (NOT_COURSE_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음 (CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PatchMapping("/{id}")
+    public ResponseEntity<ClassResponse> update(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id,
+            @RequestBody @Valid ClassUpdateRequest request) {
+        return ResponseEntity.ok(classService.update(userId, id, request));
+    }
+
+    @Operation(summary = "강의 공개", description = "강의를 공개 상태로 전환합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "강의 공개 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ClassResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 상태 전환 또는 입력값 (INVALID_STATE_TRANSITION, INVALID_INPUT)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "강의 소유자가 아님 (NOT_COURSE_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음 (CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PatchMapping("/{id}/publish")
+    public ResponseEntity<ClassResponse> publish(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id) {
+        return ResponseEntity.ok(classService.publish(userId, id));
+    }
+
+    @Operation(summary = "모집 마감", description = "강의 수강 신청 모집을 마감합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "모집 마감 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ClassResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 상태 전환 (INVALID_STATE_TRANSITION)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "강의 소유자가 아님 (NOT_COURSE_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음 (CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PatchMapping("/{id}/close")
+    public ResponseEntity<ClassResponse> close(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id) {
+        return ResponseEntity.ok(classService.close(userId, id));
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
@@ -5,6 +5,8 @@ import com.enrollment.domain.classes.dto.ClassResponse;
 import com.enrollment.domain.classes.dto.ClassUpdateRequest;
 import com.enrollment.domain.classes.entity.ClassStatus;
 import com.enrollment.domain.classes.service.ClassService;
+import com.enrollment.domain.enrollment.dto.EnrollmentWithUserResponse;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
 import com.enrollment.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -38,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ClassController {
 
     private final ClassService classService;
+    private final EnrollmentService enrollmentService;
 
     @Operation(summary = "강의 등록", description = "새로운 강의를 등록합니다.")
     @ApiResponses(value = {
@@ -169,5 +172,25 @@ public class ClassController {
             @RequestHeader("X-User-Id") Long userId,
             @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(classService.getMyClasses(userId, pageable));
+    }
+
+    @Operation(summary = "강의별 수강생 목록 조회", description = "강사 본인의 강의에 등록된 수강생 목록을 페이지 단위로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "수강생 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = Page.class))),
+        @ApiResponse(responseCode = "403", description = "강의 소유자가 아님 (NOT_COURSE_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음 (CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{id}/enrollments")
+    public ResponseEntity<Page<EnrollmentWithUserResponse>> getClassEnrollments(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id,
+            @ParameterObject @PageableDefault(size = 20, sort = "enrolledAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(enrollmentService.getClassEnrollments(userId, id, pageable));
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
@@ -1,0 +1,52 @@
+package com.enrollment.domain.classes.controller;
+
+import com.enrollment.domain.classes.dto.ClassCreateRequest;
+import com.enrollment.domain.classes.dto.ClassResponse;
+import com.enrollment.domain.classes.service.ClassService;
+import com.enrollment.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Class API", description = "강의 관리 API")
+@RestController
+@RequestMapping("/classes")
+@RequiredArgsConstructor
+public class ClassController {
+
+    private final ClassService classService;
+
+    @Operation(summary = "강의 등록", description = "새로운 강의를 등록합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "강의 등록 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ClassResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 입력값 (INVALID_INPUT)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "강사 역할이 아님 (FORBIDDEN_ROLE)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음 (USER_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping
+    public ResponseEntity<ClassResponse> create(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestBody @Valid ClassCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(classService.create(userId, request));
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/controller/ClassController.java
@@ -3,6 +3,7 @@ package com.enrollment.domain.classes.controller;
 import com.enrollment.domain.classes.dto.ClassCreateRequest;
 import com.enrollment.domain.classes.dto.ClassResponse;
 import com.enrollment.domain.classes.dto.ClassUpdateRequest;
+import com.enrollment.domain.classes.entity.ClassStatus;
 import com.enrollment.domain.classes.service.ClassService;
 import com.enrollment.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,14 +14,21 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Class API", description = "강의 관리 API")
@@ -118,5 +126,48 @@ public class ClassController {
             @RequestHeader("X-User-Id") Long userId,
             @PathVariable Long id) {
         return ResponseEntity.ok(classService.close(userId, id));
+    }
+
+    @Operation(summary = "강의 목록 조회", description = "상태별 강의 목록을 페이지 단위로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "강의 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = Page.class)))
+    })
+    @GetMapping
+    public ResponseEntity<Page<ClassResponse>> getClasses(
+            @RequestParam(defaultValue = "OPEN") ClassStatus status,
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(classService.getClasses(status, pageable));
+    }
+
+    @Operation(summary = "강의 상세 조회", description = "강의 ID로 특정 강의의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "강의 상세 조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ClassResponse.class))),
+        @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음 (CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<ClassResponse> getClass(@PathVariable Long id) {
+        return ResponseEntity.ok(classService.getClass(id));
+    }
+
+    @Operation(summary = "내 강의 목록 조회", description = "현재 사용자가 등록한 강의 목록을 페이지 단위로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "내 강의 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = Page.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음 (USER_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/me")
+    public ResponseEntity<Page<ClassResponse>> getMyClasses(
+            @RequestHeader("X-User-Id") Long userId,
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(classService.getMyClasses(userId, pageable));
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/dto/ClassCreateRequest.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/dto/ClassCreateRequest.java
@@ -1,0 +1,19 @@
+package com.enrollment.domain.classes.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record ClassCreateRequest(
+        @NotBlank @Size(max = 100) String title,
+        @Size(max = 2000) String description,
+        @NotNull @PositiveOrZero Integer price,
+        @NotNull @Positive Integer capacity,
+        @NotNull LocalDate startDate,
+        @NotNull LocalDate endDate
+) {
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/dto/ClassResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/dto/ClassResponse.java
@@ -1,0 +1,37 @@
+package com.enrollment.domain.classes.dto;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ClassResponse(
+        Long classId,
+        String title,
+        String description,
+        Integer price,
+        Integer capacity,
+        Integer enrolledCount,
+        LocalDate startDate,
+        LocalDate endDate,
+        String status,
+        String creatorName,
+        LocalDateTime createdAt
+) {
+
+    public static ClassResponse from(ClassEntity entity) {
+        return new ClassResponse(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getDescription(),
+                entity.getPrice(),
+                entity.getCapacity(),
+                entity.getEnrolledCount(),
+                entity.getStartDate(),
+                entity.getEndDate(),
+                entity.getStatus().name(),
+                entity.getCreatedBy().getName(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/dto/ClassUpdateRequest.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/dto/ClassUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.enrollment.domain.classes.dto;
+
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record ClassUpdateRequest(
+        @Size(max = 100) String title,
+        @Size(max = 2000) String description,
+        Integer price,
+        Integer capacity,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
@@ -123,6 +123,11 @@ public class ClassEntity extends BaseEntity {
         this.enrolledCount++;
     }
 
+    // 정원 여유 확인
+    public boolean hasVacancy() {
+        return this.enrolledCount < this.capacity;
+    }
+
     // 수강생 수 감소
     public void decrementEnrolled() {
         if (this.enrolledCount <= 0) {

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
@@ -1,0 +1,134 @@
+package com.enrollment.domain.classes.entity;
+
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.global.entity.BaseEntity;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "classes")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ClassEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "class_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(nullable = false)
+    private Integer capacity;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer enrolledCount = 0;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ClassStatus status;
+
+    @Version
+    private Long version;
+
+    public void publish() {
+        validateTransition(ClassStatus.OPEN);
+        validateFieldsForPublish();
+        this.status = ClassStatus.OPEN;
+    }
+
+    public void close() {
+        validateTransition(ClassStatus.CLOSED);
+        this.status = ClassStatus.CLOSED;
+    }
+
+    public void update(String title, String description, Integer price,
+                       Integer capacity, LocalDate startDate, LocalDate endDate) {
+        if (this.status != ClassStatus.DRAFT) {
+            throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+        if (title != null) this.title = title;
+        if (description != null) this.description = description;
+        if (price != null) {
+            if (price < 0) throw new BusinessException(ErrorCode.INVALID_INPUT);
+            this.price = price;
+        }
+        if (capacity != null) {
+            if (capacity <= 0) throw new BusinessException(ErrorCode.INVALID_INPUT);
+            this.capacity = capacity;
+        }
+        if (startDate != null) this.startDate = startDate;
+        if (endDate != null) this.endDate = endDate;
+        if (this.startDate != null && this.endDate != null) {
+            if (!this.endDate.isAfter(this.startDate)) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT);
+            }
+        }
+    }
+
+    public void validateOwner(Long userId) {
+        if (this.createdBy == null || !this.createdBy.getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOT_COURSE_OWNER);
+        }
+    }
+
+    private void validateTransition(ClassStatus target) {
+        if (!this.status.canTransitionTo(target)) {
+            throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+    }
+
+    private void validateFieldsForPublish() {
+        if (price == null || price < 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (capacity == null || capacity <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (startDate == null || endDate == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (!endDate.isAfter(startDate)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassEntity.java
@@ -70,17 +70,20 @@ public class ClassEntity extends BaseEntity {
     @Version
     private Long version;
 
+    // 강의 공개
     public void publish() {
         validateTransition(ClassStatus.OPEN);
         validateFieldsForPublish();
         this.status = ClassStatus.OPEN;
     }
 
+    // 강의 모집 마감
     public void close() {
         validateTransition(ClassStatus.CLOSED);
         this.status = ClassStatus.CLOSED;
     }
 
+    // 강의 수정
     public void update(String title, String description, Integer price,
                        Integer capacity, LocalDate startDate, LocalDate endDate) {
         if (this.status != ClassStatus.DRAFT) {
@@ -105,18 +108,37 @@ public class ClassEntity extends BaseEntity {
         }
     }
 
+    // 강의 소유자 검증
     public void validateOwner(Long userId) {
         if (this.createdBy == null || !this.createdBy.getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NOT_COURSE_OWNER);
         }
     }
 
+    // 수강생 수 증가
+    public void incrementEnrolled() {
+        if (this.enrolledCount >= this.capacity) {
+            throw new BusinessException(ErrorCode.CAPACITY_EXCEEDED);
+        }
+        this.enrolledCount++;
+    }
+
+    // 수강생 수 감소
+    public void decrementEnrolled() {
+        if (this.enrolledCount <= 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        this.enrolledCount--;
+    }
+
+    // 상태 전환 검증
     private void validateTransition(ClassStatus target) {
         if (!this.status.canTransitionTo(target)) {
             throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
         }
     }
 
+    // 강의 공개 필드 검증
     private void validateFieldsForPublish() {
         if (price == null || price < 0) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassStatus.java
@@ -3,6 +3,7 @@ package com.enrollment.domain.classes.entity;
 public enum ClassStatus {
     DRAFT, OPEN, CLOSED;
 
+    // 상태 전환 가능 여부 검증
     public boolean canTransitionTo(ClassStatus target) {
         return switch (this) {
             case DRAFT -> target == OPEN;

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/entity/ClassStatus.java
@@ -1,0 +1,13 @@
+package com.enrollment.domain.classes.entity;
+
+public enum ClassStatus {
+    DRAFT, OPEN, CLOSED;
+
+    public boolean canTransitionTo(ClassStatus target) {
+        return switch (this) {
+            case DRAFT -> target == OPEN;
+            case OPEN -> target == CLOSED;
+            case CLOSED -> false;
+        };
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/repository/ClassRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/repository/ClassRepository.java
@@ -1,0 +1,30 @@
+package com.enrollment.domain.classes.repository;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ClassRepository extends JpaRepository<ClassEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM ClassEntity c JOIN FETCH c.createdBy WHERE c.id = :id")
+    Optional<ClassEntity> findByIdForUpdate(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = "createdBy")
+    Optional<ClassEntity> findWithCreatorById(Long id);
+
+    @EntityGraph(attributePaths = "createdBy")
+    Page<ClassEntity> findByStatus(ClassStatus status, Pageable pageable);
+
+    @EntityGraph(attributePaths = "createdBy")
+    Page<ClassEntity> findByCreatedById(Long userId, Pageable pageable);
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/repository/ClassRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/repository/ClassRepository.java
@@ -15,16 +15,20 @@ import java.util.Optional;
 
 public interface ClassRepository extends JpaRepository<ClassEntity, Long> {
 
+    // 강의 조회
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM ClassEntity c JOIN FETCH c.createdBy WHERE c.id = :id")
     Optional<ClassEntity> findByIdForUpdate(@Param("id") Long id);
 
+    // 강의 소유자 조회
     @EntityGraph(attributePaths = "createdBy")
     Optional<ClassEntity> findWithCreatorById(Long id);
 
+    // 강의 상태별 목록 조회
     @EntityGraph(attributePaths = "createdBy")
     Page<ClassEntity> findByStatus(ClassStatus status, Pageable pageable);
 
+    // 강의 소유자별 목록 조회
     @EntityGraph(attributePaths = "createdBy")
     Page<ClassEntity> findByCreatedById(Long userId, Pageable pageable);
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/service/ClassService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/service/ClassService.java
@@ -1,0 +1,55 @@
+package com.enrollment.domain.classes.service;
+
+import com.enrollment.domain.classes.dto.ClassCreateRequest;
+import com.enrollment.domain.classes.dto.ClassResponse;
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClassService {
+
+    private final ClassRepository classRepository;
+    private final UserRepository userRepository;
+
+    // 강의 등록
+    @Transactional
+    public ClassResponse create(Long userId, ClassCreateRequest request) {
+        if (request.startDate() != null && request.endDate() != null
+                && !request.endDate().isAfter(request.startDate())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getRole() != UserRole.CREATOR) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_ROLE);
+        }
+
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(user)
+                .title(request.title())
+                .description(request.description())
+                .price(request.price())
+                .capacity(request.capacity())
+                .enrolledCount(0)
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .status(ClassStatus.DRAFT)
+                .build();
+
+        ClassEntity saved = classRepository.save(entity);
+        return ClassResponse.from(saved);
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/service/ClassService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/service/ClassService.java
@@ -12,6 +12,8 @@ import com.enrollment.domain.user.repository.UserRepository;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -83,5 +85,27 @@ public class ClassService {
         entity.validateOwner(userId);
         entity.close();
         return ClassResponse.from(entity);
+    }
+
+    // 강의 목록 조회
+    public Page<ClassResponse> getClasses(ClassStatus status, Pageable pageable) {
+        return classRepository.findByStatus(status, pageable)
+                .map(ClassResponse::from);
+    }
+
+    // 강의 상세 조회
+    public ClassResponse getClass(Long classId) {
+        ClassEntity entity = classRepository.findWithCreatorById(classId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+        return ClassResponse.from(entity);
+    }
+
+    // 내 강의 목록 조회
+    public Page<ClassResponse> getMyClasses(Long userId, Pageable pageable) {
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+        return classRepository.findByCreatedById(userId, pageable)
+                .map(ClassResponse::from);
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/classes/service/ClassService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/classes/service/ClassService.java
@@ -2,6 +2,7 @@ package com.enrollment.domain.classes.service;
 
 import com.enrollment.domain.classes.dto.ClassCreateRequest;
 import com.enrollment.domain.classes.dto.ClassResponse;
+import com.enrollment.domain.classes.dto.ClassUpdateRequest;
 import com.enrollment.domain.classes.entity.ClassEntity;
 import com.enrollment.domain.classes.entity.ClassStatus;
 import com.enrollment.domain.classes.repository.ClassRepository;
@@ -51,5 +52,36 @@ public class ClassService {
 
         ClassEntity saved = classRepository.save(entity);
         return ClassResponse.from(saved);
+    }
+
+    // 강의 수정
+    @Transactional
+    public ClassResponse update(Long userId, Long classId, ClassUpdateRequest request) {
+        ClassEntity entity = classRepository.findWithCreatorById(classId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+        entity.validateOwner(userId);
+        entity.update(request.title(), request.description(), request.price(),
+                request.capacity(), request.startDate(), request.endDate());
+        return ClassResponse.from(entity);
+    }
+
+    // 강의 공개
+    @Transactional
+    public ClassResponse publish(Long userId, Long classId) {
+        ClassEntity entity = classRepository.findByIdForUpdate(classId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+        entity.validateOwner(userId);
+        entity.publish();
+        return ClassResponse.from(entity);
+    }
+
+    // 모집 마감
+    @Transactional
+    public ClassResponse close(Long userId, Long classId) {
+        ClassEntity entity = classRepository.findByIdForUpdate(classId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+        entity.validateOwner(userId);
+        entity.close();
+        return ClassResponse.from(entity);
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
@@ -14,6 +14,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -48,5 +50,49 @@ public class EnrollmentController {
             @RequestHeader("X-User-Id") Long userId,
             @RequestBody @Valid EnrollmentCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(enrollmentService.enroll(userId, request));
+    }
+
+    @Operation(summary = "결제", description = "수강 신청을 결제하여 CONFIRMED 상태로 전환합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "결제 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = EnrollmentResponse.class))),
+        @ApiResponse(responseCode = "400", description = "이미 확정/취소된 신청 또는 잘못된 상태 전환 (INVALID_STATE_TRANSITION)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "수강 신청 소유자가 아님 (NOT_ENROLLMENT_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "수강 신청을 찾을 수 없음 (ENROLLMENT_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PatchMapping("/{id}/pay")
+    public ResponseEntity<EnrollmentResponse> pay(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id) {
+        return ResponseEntity.ok(enrollmentService.pay(userId, id));
+    }
+
+    @Operation(summary = "수강 취소", description = "수강 신청을 취소합니다. CONFIRMED 상태라면 7일 이내에만 가능하며 환불 처리됩니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "취소 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = EnrollmentResponse.class))),
+        @ApiResponse(responseCode = "400", description = "취소 가능 기간 초과 또는 이미 취소됨 (CANCEL_PERIOD_EXPIRED, ALREADY_CANCELLED)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "수강 신청 소유자가 아님 (NOT_ENROLLMENT_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "수강 신청을 찾을 수 없음 (ENROLLMENT_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PatchMapping("/{id}/cancel")
+    public ResponseEntity<EnrollmentResponse> cancel(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long id) {
+        return ResponseEntity.ok(enrollmentService.cancel(userId, id));
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
@@ -1,0 +1,52 @@
+package com.enrollment.domain.enrollment.controller;
+
+import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
+import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Enrollment API", description = "수강 신청 관리 API")
+@RestController
+@RequestMapping("/enrollments")
+@RequiredArgsConstructor
+public class EnrollmentController {
+
+    private final EnrollmentService enrollmentService;
+
+    @Operation(summary = "수강 신청", description = "강의를 수강 신청합니다. 정원/중복 체크 후 PENDING 상태로 생성됩니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "수강 신청 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = EnrollmentResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 입력값 또는 상태 (INVALID_INPUT, INVALID_STATE_TRANSITION, CAPACITY_EXCEEDED)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자 또는 강의를 찾을 수 없음 (USER_NOT_FOUND, CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "409", description = "이미 신청한 강의 (ALREADY_ENROLLED)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping
+    public ResponseEntity<EnrollmentResponse> enroll(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestBody @Valid EnrollmentCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(enrollmentService.enroll(userId, request));
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/controller/EnrollmentController.java
@@ -12,8 +12,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -94,5 +100,21 @@ public class EnrollmentController {
             @RequestHeader("X-User-Id") Long userId,
             @PathVariable Long id) {
         return ResponseEntity.ok(enrollmentService.cancel(userId, id));
+    }
+
+    @Operation(summary = "내 수강 신청 목록 조회", description = "현재 사용자의 수강 신청 목록을 페이지 단위로 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "수강 신청 목록 조회 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = Page.class))),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음 (USER_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/me")
+    public ResponseEntity<Page<EnrollmentResponse>> getMyEnrollments(
+            @RequestHeader("X-User-Id") Long userId,
+            @ParameterObject @PageableDefault(size = 20, sort = "enrolledAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(enrollmentService.getMyEnrollments(userId, pageable));
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentCreateRequest.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentCreateRequest.java
@@ -1,0 +1,8 @@
+package com.enrollment.domain.enrollment.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EnrollmentCreateRequest(
+        @NotNull Long classId
+) {
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentCreateRequest.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentCreateRequest.java
@@ -4,5 +4,4 @@ import jakarta.validation.constraints.NotNull;
 
 public record EnrollmentCreateRequest(
         @NotNull Long classId
-) {
-}
+) {}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentResponse.java
@@ -14,6 +14,7 @@ public record EnrollmentResponse(
         LocalDateTime cancelledAt
 ) {
 
+    // 수강 신청 응답 생성
     public static EnrollmentResponse from(Enrollment enrollment) {
         return new EnrollmentResponse(
                 enrollment.getId(),

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentResponse.java
@@ -1,0 +1,28 @@
+package com.enrollment.domain.enrollment.dto;
+
+import com.enrollment.domain.enrollment.entity.Enrollment;
+
+import java.time.LocalDateTime;
+
+public record EnrollmentResponse(
+        Long enrollmentId,
+        Long classId,
+        String classTitle,
+        String status,
+        LocalDateTime enrolledAt,
+        LocalDateTime confirmedAt,
+        LocalDateTime cancelledAt
+) {
+
+    public static EnrollmentResponse from(Enrollment enrollment) {
+        return new EnrollmentResponse(
+                enrollment.getId(),
+                enrollment.getClassEntity().getId(),
+                enrollment.getClassEntity().getTitle(),
+                enrollment.getStatus().name(),
+                enrollment.getEnrolledAt(),
+                enrollment.getConfirmedAt(),
+                enrollment.getCancelledAt()
+        );
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentWithUserResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentWithUserResponse.java
@@ -1,0 +1,24 @@
+package com.enrollment.domain.enrollment.dto;
+
+import com.enrollment.domain.enrollment.entity.Enrollment;
+
+import java.time.LocalDateTime;
+
+public record EnrollmentWithUserResponse(
+        Long enrollmentId,
+        Long userId,
+        String userName,
+        String status,
+        LocalDateTime enrolledAt
+) {
+
+    public static EnrollmentWithUserResponse from(Enrollment enrollment) {
+        return new EnrollmentWithUserResponse(
+                enrollment.getId(),
+                enrollment.getUser().getId(),
+                enrollment.getUser().getName(),
+                enrollment.getStatus().name(),
+                enrollment.getEnrolledAt()
+        );
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentWithUserResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/dto/EnrollmentWithUserResponse.java
@@ -12,6 +12,7 @@ public record EnrollmentWithUserResponse(
         LocalDateTime enrolledAt
 ) {
 
+    // 수강 신청 응답 생성
     public static EnrollmentWithUserResponse from(Enrollment enrollment) {
         return new EnrollmentWithUserResponse(
                 enrollment.getId(),

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
@@ -1,0 +1,95 @@
+package com.enrollment.domain.enrollment.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.global.entity.BaseEntity;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "enrollments")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Enrollment extends BaseEntity {
+
+    private static final int CANCEL_WINDOW_DAYS = 7;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "enrollment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "class_id", nullable = false)
+    private ClassEntity classEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private EnrollmentStatus status;
+
+    @Column(name = "enrolled_at", nullable = false)
+    private LocalDateTime enrolledAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    public void confirm() {
+        validateTransition(EnrollmentStatus.CONFIRMED);
+        this.status = EnrollmentStatus.CONFIRMED;
+        this.confirmedAt = LocalDateTime.now();
+    }
+
+    public void cancel() {
+        if (this.status == EnrollmentStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.ALREADY_CANCELLED);
+        }
+        if (this.status == EnrollmentStatus.CONFIRMED) {
+            if (this.confirmedAt == null
+                    || this.confirmedAt.plusDays(CANCEL_WINDOW_DAYS).isBefore(LocalDateTime.now())) {
+                throw new BusinessException(ErrorCode.CANCEL_PERIOD_EXPIRED);
+            }
+        }
+        validateTransition(EnrollmentStatus.CANCELLED);
+        this.status = EnrollmentStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    public void validateOwner(Long userId) {
+        if (this.user == null || !this.user.getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOT_ENROLLMENT_OWNER);
+        }
+    }
+
+    private void validateTransition(EnrollmentStatus target) {
+        if (!this.status.canTransitionTo(target)) {
+            throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
@@ -60,12 +60,14 @@ public class Enrollment extends BaseEntity {
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
 
+    // 수강 신청 확정
     public void confirm() {
         validateTransition(EnrollmentStatus.CONFIRMED);
         this.status = EnrollmentStatus.CONFIRMED;
         this.confirmedAt = LocalDateTime.now();
     }
 
+    // 수강 신청 취소
     public void cancel() {
         if (this.status == EnrollmentStatus.CANCELLED) {
             throw new BusinessException(ErrorCode.ALREADY_CANCELLED);
@@ -81,12 +83,14 @@ public class Enrollment extends BaseEntity {
         this.cancelledAt = LocalDateTime.now();
     }
 
+    // 수강 신청 소유자 검증
     public void validateOwner(Long userId) {
         if (this.user == null || !this.user.getId().equals(userId)) {
             throw new BusinessException(ErrorCode.NOT_ENROLLMENT_OWNER);
         }
     }
 
+    // 상태 전환 검증
     private void validateTransition(EnrollmentStatus target) {
         if (!this.status.canTransitionTo(target)) {
             throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/Enrollment.java
@@ -33,6 +33,9 @@ import java.time.LocalDateTime;
 public class Enrollment extends BaseEntity {
 
     private static final int CANCEL_WINDOW_DAYS = 7;
+    // 결제 가능 시간 30분: 카드 결제 평균 + 재로그인/카드 교체 여유.
+    // 운영 중 조정 빈도가 낮다고 판단해 상수로 유지. 필요 시 application.yml로 이동.
+    private static final int PENDING_TTL_MINUTES = 30;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -60,11 +63,18 @@ public class Enrollment extends BaseEntity {
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
 
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
     // 수강 신청 확정
     public void confirm() {
+        if (isExpired()) {
+            throw new BusinessException(ErrorCode.HOLD_EXPIRED);
+        }
         validateTransition(EnrollmentStatus.CONFIRMED);
         this.status = EnrollmentStatus.CONFIRMED;
         this.confirmedAt = LocalDateTime.now();
+        this.expiresAt = null;
     }
 
     // 수강 신청 취소
@@ -81,6 +91,24 @@ public class Enrollment extends BaseEntity {
         validateTransition(EnrollmentStatus.CANCELLED);
         this.status = EnrollmentStatus.CANCELLED;
         this.cancelledAt = LocalDateTime.now();
+    }
+
+    // PENDING TTL 만료 처리 (스케줄러 전용, 사용자 취소와 구분)
+    // - cancel()과 달리 상태 전이 검증 생략 (호출부에서 PENDING + 만료 확정)
+    // - 7일 기한 검증도 불필요 (만료 자체가 시스템 자동 종료)
+    public void expire() {
+        this.status = EnrollmentStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    // TTL 만료 여부 확인
+    public boolean isExpired() {
+        return this.expiresAt != null && this.expiresAt.isBefore(LocalDateTime.now());
+    }
+
+    // 신청 / 승격 시 공통 TTL 세팅
+    public static LocalDateTime defaultExpiresAt() {
+        return LocalDateTime.now().plusMinutes(PENDING_TTL_MINUTES);
     }
 
     // 수강 신청 소유자 검증

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/EnrollmentStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/EnrollmentStatus.java
@@ -3,6 +3,7 @@ package com.enrollment.domain.enrollment.entity;
 public enum EnrollmentStatus {
     PENDING, CONFIRMED, CANCELLED;
 
+    // 상태 전환 가능 여부 검증
     public boolean canTransitionTo(EnrollmentStatus target) {
         return switch (this) {
             case PENDING -> target == CONFIRMED || target == CANCELLED;

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/EnrollmentStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/entity/EnrollmentStatus.java
@@ -1,0 +1,13 @@
+package com.enrollment.domain.enrollment.entity;
+
+public enum EnrollmentStatus {
+    PENDING, CONFIRMED, CANCELLED;
+
+    public boolean canTransitionTo(EnrollmentStatus target) {
+        return switch (this) {
+            case PENDING -> target == CONFIRMED || target == CANCELLED;
+            case CONFIRMED -> target == CANCELLED;
+            case CANCELLED -> false;
+        };
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
@@ -40,4 +41,10 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             @Param("classId") Long classId,
             @Param("userId") Long userId,
             @Param("statuses") Collection<EnrollmentStatus> statuses);
+
+    // 활성 수강 신청(PENDING/CONFIRMED) 존재 여부 검증
+    default boolean existsActiveByClassIdAndUserId(Long classId, Long userId) {
+        return existsByClassIdAndUserIdAndStatusIn(classId, userId,
+                List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED));
+    }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,0 +1,43 @@
+package com.enrollment.domain.enrollment.repository;
+
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+    // 수강 신청 비관적 락 조회
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Enrollment e JOIN FETCH e.classEntity JOIN FETCH e.user WHERE e.id = :id")
+    Optional<Enrollment> findByIdForUpdate(@Param("id") Long id);
+
+    // 수강 신청 락 없는 조회 (classEntity, user 즉시 로딩)
+    @EntityGraph(attributePaths = {"classEntity", "user"})
+    Optional<Enrollment> findWithClassAndUserById(Long id);
+
+    // 사용자별 수강 신청 목록 조회
+    @EntityGraph(attributePaths = {"classEntity", "user"})
+    Page<Enrollment> findByUserId(Long userId, Pageable pageable);
+
+    // 강의별 수강 신청 목록 조회
+    @EntityGraph(attributePaths = {"classEntity", "user"})
+    Page<Enrollment> findByClassEntityId(Long classId, Pageable pageable);
+
+    // 수강 신청 존재 여부 검증
+    @Query("SELECT (COUNT(e) > 0) FROM Enrollment e "
+            + "WHERE e.classEntity.id = :classId AND e.user.id = :userId AND e.status IN :statuses")
+    boolean existsByClassIdAndUserIdAndStatusIn(
+            @Param("classId") Long classId,
+            @Param("userId") Long userId,
+            @Param("statuses") Collection<EnrollmentStatus> statuses);
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/repository/EnrollmentRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -47,4 +48,12 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
         return existsByClassIdAndUserIdAndStatusIn(classId, userId,
                 List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED));
     }
+
+    // 만료된 PENDING 수강 신청 스캔 (오래 방치된 것부터 FIFO 처리)
+    @Query("SELECT e FROM Enrollment e JOIN FETCH e.classEntity "
+            + "WHERE e.status = :status AND e.expiresAt < :now "
+            + "ORDER BY e.expiresAt ASC")
+    List<Enrollment> findExpiredPendings(@Param("status") EnrollmentStatus status,
+                                         @Param("now") LocalDateTime now,
+                                         Pageable pageable);
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/scheduler/EnrollmentExpirationScheduler.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/scheduler/EnrollmentExpirationScheduler.java
@@ -1,0 +1,72 @@
+package com.enrollment.domain.enrollment.scheduler;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.waitlist.service.WaitlistService;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EnrollmentExpirationScheduler {
+
+    // 배치 크기 100 + 1분 주기 = 시간당 최대 6,000건 처리.
+    // 이보다 많은 만료율이 예상되면 BATCH_SIZE 상향 또는 다중 tick drain 방식으로 전환.
+    private static final int BATCH_SIZE = 100;
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final ClassRepository classRepository;
+    private final WaitlistService waitlistService;
+    private final TransactionTemplate transactionTemplate;
+
+    // 만료된 PENDING 스캔 (1분 주기)
+    @Scheduled(fixedDelay = 60_000)  // 1분 주기 — DB 부하/응답 지연 균형
+    public void expirePendings() {
+        List<Enrollment> expired = enrollmentRepository.findExpiredPendings(
+                EnrollmentStatus.PENDING, LocalDateTime.now(), PageRequest.of(0, BATCH_SIZE));
+        for (Enrollment e : expired) {
+            try {
+                transactionTemplate.executeWithoutResult(s -> expireOne(e.getId()));
+            } catch (Exception ex) {
+                // 한 건 실패가 전체 배치 중단을 막지 않음
+                log.warn("[Expire] Failed to expire enrollment={}", e.getId(), ex);
+            }
+        }
+    }
+
+    // 단건 만료 처리 (독립 트랜잭션)
+    public void expireOne(Long enrollmentId) {
+        Enrollment enrollment = enrollmentRepository.findByIdForUpdate(enrollmentId)
+                .orElse(null);
+        if (enrollment == null
+                || enrollment.getStatus() != EnrollmentStatus.PENDING
+                || !enrollment.isExpired()) {
+            return;
+        }
+        ClassEntity classEntity = classRepository.findByIdForUpdate(enrollment.getClassEntity().getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 만료 처리 + 좌석 복구
+        enrollment.expire();
+        classEntity.decrementEnrolled();
+
+        log.info("[Expire] enrollment={} user={} class={} expired, seat released",
+                enrollmentId, enrollment.getUser().getId(), classEntity.getId());
+
+        // 체인 승격
+        waitlistService.promoteNext(classEntity);
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -72,13 +72,14 @@ public class EnrollmentService {
                         .user(user)
                         .status(EnrollmentStatus.PENDING)
                         .enrolledAt(LocalDateTime.now())
+                        .expiresAt(Enrollment.defaultExpiresAt())
                         .build()));
     }
 
     // 결제
     @Transactional
     public EnrollmentResponse pay(Long userId, Long enrollmentId) {
-        
+
         // 수강 신청 조회 (본인 row 상태 변경만이라 락 불필요, 상태머신 + uk_payment_paid 부분 유니크 인덱스로 방어)
         Enrollment enrollment = enrollmentRepository.findWithClassAndUserById(enrollmentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -80,8 +80,8 @@ public class EnrollmentService {
     @Transactional
     public EnrollmentResponse pay(Long userId, Long enrollmentId) {
 
-        // 수강 신청 조회 (본인 row 상태 변경만이라 락 불필요, 상태머신 + uk_payment_paid 부분 유니크 인덱스로 방어)
-        Enrollment enrollment = enrollmentRepository.findWithClassAndUserById(enrollmentId)
+        // 수강 신청 조회 (만료 스케줄러와의 race 방지 위해 비관적 락으로 직렬화)
+        Enrollment enrollment = enrollmentRepository.findByIdForUpdate(enrollmentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
 
         // 수강 신청 소유자 검증

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -13,6 +13,7 @@ import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
 import com.enrollment.domain.payment.repository.PaymentRepository;
 import com.enrollment.domain.user.entity.User;
 import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.service.WaitlistService;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -36,11 +37,12 @@ public class EnrollmentService {
     private final PaymentRepository paymentRepository;
     private final ClassRepository classRepository;
     private final UserRepository userRepository;
+    private final WaitlistService waitlistService;
 
     // 수강 신청
     @Transactional
     public EnrollmentResponse enroll(Long userId, EnrollmentCreateRequest request) {
-
+        
         // 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -76,7 +78,7 @@ public class EnrollmentService {
     // 결제
     @Transactional
     public EnrollmentResponse pay(Long userId, Long enrollmentId) {
-
+        
         // 수강 신청 조회 (본인 row 상태 변경만이라 락 불필요, 상태머신 + uk_payment_paid 부분 유니크 인덱스로 방어)
         Enrollment enrollment = enrollmentRepository.findWithClassAndUserById(enrollmentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
@@ -89,14 +91,14 @@ public class EnrollmentService {
 
         // 결제 저장
         paymentRepository.save(Payment.paid(enrollment, enrollment.getClassEntity().getPrice()));
-
+        
         return EnrollmentResponse.from(enrollment);
     }
 
     // 수강 취소
     @Transactional
     public EnrollmentResponse cancel(Long userId, Long enrollmentId) {
-
+        
         // 수강 신청 조회
         Enrollment enrollment = enrollmentRepository.findByIdForUpdate(enrollmentId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
@@ -122,12 +124,15 @@ public class EnrollmentService {
             paymentRepository.save(Payment.refunded(enrollment, classEntity.getPrice()));
         }
 
+        // 대기열 선두 자동 승격
+        waitlistService.promoteNext(classEntity);
+
         return EnrollmentResponse.from(enrollment);
     }
 
     // 내 수강 신청 목록 조회
     public Page<EnrollmentResponse> getMyEnrollments(Long userId, Pageable pageable) {
-
+        
         // 사용자 존재 여부 검증
         if (!userRepository.existsById(userId)) {
             throw new BusinessException(ErrorCode.USER_NOT_FOUND);
@@ -139,7 +144,7 @@ public class EnrollmentService {
 
     // 강의별 수강생 목록 조회 (강사 전용)
     public Page<EnrollmentWithUserResponse> getClassEnrollments(Long userId, Long classId, Pageable pageable) {
-
+        
         // 강의 조회
         ClassEntity classEntity = classRepository.findWithCreatorById(classId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -1,0 +1,69 @@
+package com.enrollment.domain.enrollment.service;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
+import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EnrollmentService {
+
+    private static final List<EnrollmentStatus> ACTIVE_STATUSES =
+            List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED);
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final ClassRepository classRepository;
+    private final UserRepository userRepository;
+
+    // 수강 신청
+    @Transactional
+    public EnrollmentResponse enroll(Long userId, EnrollmentCreateRequest request) {
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 강의 조회
+        ClassEntity classEntity = classRepository.findByIdForUpdate(request.classId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 강의 상태 검증
+        if (classEntity.getStatus() != ClassStatus.OPEN) {
+            throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+
+        // 수강 신청 존재 여부 검증
+        if (enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                classEntity.getId(), user.getId(), ACTIVE_STATUSES)) {
+            throw new BusinessException(ErrorCode.ALREADY_ENROLLED);
+        }
+
+        // 좌석 차감
+        classEntity.incrementEnrolled();
+
+        // 수강 신청 저장
+        return EnrollmentResponse.from(enrollmentRepository.save(
+                Enrollment.builder()
+                        .classEntity(classEntity)
+                        .user(user)
+                        .status(EnrollmentStatus.PENDING)
+                        .enrolledAt(LocalDateTime.now())
+                        .build()));
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -7,7 +7,9 @@ import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
 import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
 import com.enrollment.domain.enrollment.entity.Enrollment;
 import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.payment.entity.Payment;
 import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.payment.repository.PaymentRepository;
 import com.enrollment.domain.user.entity.User;
 import com.enrollment.domain.user.repository.UserRepository;
 import com.enrollment.global.error.exception.BusinessException;
@@ -28,6 +30,7 @@ public class EnrollmentService {
             List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED);
 
     private final EnrollmentRepository enrollmentRepository;
+    private final PaymentRepository paymentRepository;
     private final ClassRepository classRepository;
     private final UserRepository userRepository;
 
@@ -65,5 +68,57 @@ public class EnrollmentService {
                         .status(EnrollmentStatus.PENDING)
                         .enrolledAt(LocalDateTime.now())
                         .build()));
+    }
+
+    // 결제
+    @Transactional
+    public EnrollmentResponse pay(Long userId, Long enrollmentId) {
+
+        // 수강 신청 조회 (본인 row 상태 변경만이라 락 불필요, 상태머신 + uk_payment_paid 부분 유니크 인덱스로 방어)
+        Enrollment enrollment = enrollmentRepository.findWithClassAndUserById(enrollmentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
+
+        // 수강 신청 소유자 검증
+        enrollment.validateOwner(userId);
+
+        // 수강 신청 확정
+        enrollment.confirm();
+
+        // 결제 저장
+        paymentRepository.save(Payment.paid(enrollment, enrollment.getClassEntity().getPrice()));
+
+        return EnrollmentResponse.from(enrollment);
+    }
+
+    // 수강 취소
+    @Transactional
+    public EnrollmentResponse cancel(Long userId, Long enrollmentId) {
+
+        // 수강 신청 조회
+        Enrollment enrollment = enrollmentRepository.findByIdForUpdate(enrollmentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
+
+        // 수강 신청 소유자 검증
+        enrollment.validateOwner(userId);
+
+        // CONFIRMED 여부 확인
+        boolean wasConfirmed = enrollment.getStatus() == EnrollmentStatus.CONFIRMED;
+
+        // 강의 조회
+        ClassEntity classEntity = classRepository.findByIdForUpdate(enrollment.getClassEntity().getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 수강 신청 취소
+        enrollment.cancel();
+
+        // 강의 수강생 수 감소
+        classEntity.decrementEnrolled();
+
+        // 환불 이력 저장
+        if (wasConfirmed) {
+            paymentRepository.save(Payment.refunded(enrollment, classEntity.getPrice()));
+        }
+
+        return EnrollmentResponse.from(enrollment);
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/enrollment/service/EnrollmentService.java
@@ -5,6 +5,7 @@ import com.enrollment.domain.classes.entity.ClassStatus;
 import com.enrollment.domain.classes.repository.ClassRepository;
 import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
 import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.dto.EnrollmentWithUserResponse;
 import com.enrollment.domain.enrollment.entity.Enrollment;
 import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
 import com.enrollment.domain.payment.entity.Payment;
@@ -15,6 +16,8 @@ import com.enrollment.domain.user.repository.UserRepository;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -120,5 +123,31 @@ public class EnrollmentService {
         }
 
         return EnrollmentResponse.from(enrollment);
+    }
+
+    // 내 수강 신청 목록 조회
+    public Page<EnrollmentResponse> getMyEnrollments(Long userId, Pageable pageable) {
+
+        // 사용자 존재 여부 검증
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        return enrollmentRepository.findByUserId(userId, pageable)
+                .map(EnrollmentResponse::from);
+    }
+
+    // 강의별 수강생 목록 조회 (강사 전용)
+    public Page<EnrollmentWithUserResponse> getClassEnrollments(Long userId, Long classId, Pageable pageable) {
+
+        // 강의 조회
+        ClassEntity classEntity = classRepository.findWithCreatorById(classId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 강의 소유자 검증
+        classEntity.validateOwner(userId);
+
+        return enrollmentRepository.findByClassEntityId(classId, pageable)
+                .map(EnrollmentWithUserResponse::from);
     }
 }

--- a/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/Payment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/Payment.java
@@ -1,0 +1,68 @@
+package com.enrollment.domain.payment.entity;
+
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "enrollment_id", nullable = false)
+    private Enrollment enrollment;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentStatus status;
+
+    @Column(name = "paid_at", nullable = false)
+    private LocalDateTime paidAt;
+
+    public static Payment paid(Enrollment enrollment, Integer amount) {
+        return Payment.builder()
+                .enrollment(enrollment)
+                .amount(amount)
+                .status(PaymentStatus.PAID)
+                .paidAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Payment refunded(Enrollment enrollment, Integer amount) {
+        return Payment.builder()
+                .enrollment(enrollment)
+                .amount(amount)
+                .status(PaymentStatus.REFUNDED)
+                .paidAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/Payment.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/Payment.java
@@ -48,6 +48,7 @@ public class Payment extends BaseEntity {
     @Column(name = "paid_at", nullable = false)
     private LocalDateTime paidAt;
 
+    // 결제 완료
     public static Payment paid(Enrollment enrollment, Integer amount) {
         return Payment.builder()
                 .enrollment(enrollment)
@@ -57,6 +58,7 @@ public class Payment extends BaseEntity {
                 .build();
     }
 
+    // 결제 취소
     public static Payment refunded(Enrollment enrollment, Integer amount) {
         return Payment.builder()
                 .enrollment(enrollment)

--- a/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/PaymentStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.enrollment.domain.payment.entity;
+
+public enum PaymentStatus {
+    PAID, REFUNDED, FAILED
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/payment/repository/PaymentRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.enrollment.domain.payment.repository;
+
+import com.enrollment.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/user/entity/User.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/user/entity/User.java
@@ -1,0 +1,37 @@
+package com.enrollment.domain.user.entity;
+
+import com.enrollment.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/user/entity/UserRole.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/user/entity/UserRole.java
@@ -1,0 +1,9 @@
+package com.enrollment.domain.user.entity;
+
+/**
+ * 사용자 역할. CREATOR = 강사, CLASSMATE = 수강생
+ */
+public enum UserRole {
+    CREATOR,
+    CLASSMATE
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/user/repository/UserRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.enrollment.domain.user.repository;
+
+import com.enrollment.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/controller/WaitlistController.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/controller/WaitlistController.java
@@ -1,0 +1,69 @@
+package com.enrollment.domain.waitlist.controller;
+
+import com.enrollment.domain.waitlist.dto.WaitlistResponse;
+import com.enrollment.domain.waitlist.service.WaitlistService;
+import com.enrollment.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Waitlist API", description = "대기열 관리 API")
+@RestController
+@RequestMapping("/classes/{classId}/waitlist")
+@RequiredArgsConstructor
+public class WaitlistController {
+
+    private final WaitlistService waitlistService;
+
+    @Operation(summary = "대기열 등록", description = "정원이 찬 강의에 대기열로 등록합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "대기열 등록 성공",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = WaitlistResponse.class))),
+        @ApiResponse(responseCode = "400", description = "대기열 등록 불가 상태 (WAITLIST_NOT_ALLOWED, INVALID_INPUT)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "사용자 또는 강의를 찾을 수 없음 (USER_NOT_FOUND, CLASS_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "409", description = "이미 신청 또는 대기 중 (ALREADY_ENROLLED, ALREADY_IN_WAITLIST)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping
+    public ResponseEntity<WaitlistResponse> register(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long classId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(waitlistService.register(userId, classId));
+    }
+
+    @Operation(summary = "대기열 철회", description = "본인이 등록한 대기열을 철회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "대기열 철회 성공"),
+        @ApiResponse(responseCode = "403", description = "대기열 소유자가 아님 (NOT_WAITLIST_OWNER)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "대기열 정보를 찾을 수 없음 (WAITLIST_NOT_FOUND)",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> cancel(
+            @RequestHeader("X-User-Id") Long userId,
+            @PathVariable Long classId) {
+        waitlistService.cancelWaitlist(userId, classId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/dto/WaitlistResponse.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/dto/WaitlistResponse.java
@@ -1,0 +1,24 @@
+package com.enrollment.domain.waitlist.dto;
+
+import com.enrollment.domain.waitlist.entity.Waitlist;
+
+import java.time.LocalDateTime;
+
+public record WaitlistResponse(
+        Long waitlistId,
+        Long classId,
+        String classTitle,
+        String status,
+        LocalDateTime createdAt
+) {
+
+    public static WaitlistResponse from(Waitlist waitlist) {
+        return new WaitlistResponse(
+                waitlist.getId(),
+                waitlist.getClassEntity().getId(),
+                waitlist.getClassEntity().getTitle(),
+                waitlist.getStatus().name(),
+                waitlist.getCreatedAt()
+        );
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/entity/Waitlist.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/entity/Waitlist.java
@@ -1,0 +1,99 @@
+package com.enrollment.domain.waitlist.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.global.entity.BaseEntity;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "waitlists")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Waitlist extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "waitlist_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "class_id", nullable = false)
+    private ClassEntity classEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private WaitlistStatus status;
+
+    @Column(name = "promoted_enrollment_id")
+    private Long promotedEnrollmentId;
+
+    @Column(name = "promoted_at")
+    private LocalDateTime promotedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    // 대기열 승격
+    public void promote(Long enrollmentId) {
+        validateTransition(WaitlistStatus.PROMOTED);
+        this.status = WaitlistStatus.PROMOTED;
+        this.promotedEnrollmentId = enrollmentId;
+        this.promotedAt = LocalDateTime.now();
+    }
+
+    // 대기열 철회
+    public void cancel() {
+        if (this.status == WaitlistStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.ALREADY_CANCELLED);
+        }
+        validateTransition(WaitlistStatus.CANCELLED);
+        this.status = WaitlistStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    // 선두 스킵 — 승격 시 이미 활성 수강 신청을 가진 대기자를 건너뛰기 위한 방어 처리.
+    // 호출부(WaitlistService.promoteNext)가 WAITING 상태만 넘겨주는 것을 보장하므로 상태머신 검증 생략.
+    public void skip() {
+        this.status = WaitlistStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    // 대기열 소유자 검증
+    public void validateOwner(Long userId) {
+        if (this.user == null || !this.user.getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.NOT_WAITLIST_OWNER);
+        }
+    }
+
+    // 상태 전환 검증
+    private void validateTransition(WaitlistStatus target) {
+        if (!this.status.canTransitionTo(target)) {
+            throw new BusinessException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/entity/WaitlistStatus.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/entity/WaitlistStatus.java
@@ -1,0 +1,14 @@
+package com.enrollment.domain.waitlist.entity;
+
+public enum WaitlistStatus {
+    WAITING, PROMOTED, CANCELLED;
+
+    // 상태 전환 가능 여부 검증
+    public boolean canTransitionTo(WaitlistStatus target) {
+        return switch (this) {
+            case WAITING -> target == PROMOTED || target == CANCELLED;
+            case PROMOTED -> false;
+            case CANCELLED -> false;
+        };
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/repository/WaitlistRepository.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/repository/WaitlistRepository.java
@@ -1,0 +1,42 @@
+package com.enrollment.domain.waitlist.repository;
+
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WaitlistRepository extends JpaRepository<Waitlist, Long> {
+
+    // 대기열 선두 비관적 락 조회 (FIFO: createdAt ASC, id ASC 타이브레이커). Pageable.ofSize(1) 로 LIMIT 1
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT w FROM Waitlist w JOIN FETCH w.user "
+            + "WHERE w.classEntity.id = :classId AND w.status = com.enrollment.domain.waitlist.entity.WaitlistStatus.WAITING "
+            + "ORDER BY w.createdAt ASC, w.id ASC")
+    List<Waitlist> findWaitingForUpdate(@Param("classId") Long classId, Pageable pageable);
+
+    // 대기열 선두 단건 조회 편의 메서드
+    default Optional<Waitlist> findFirstWaitingForUpdate(Long classId) {
+        return findWaitingForUpdate(classId, Pageable.ofSize(1)).stream().findFirst();
+    }
+
+    // 대기열 존재 여부 검증
+    @Query("SELECT (COUNT(w) > 0) FROM Waitlist w "
+            + "WHERE w.classEntity.id = :classId AND w.user.id = :userId AND w.status = :status")
+    boolean existsByClassIdAndUserIdAndStatus(@Param("classId") Long classId,
+                                              @Param("userId") Long userId,
+                                              @Param("status") WaitlistStatus status);
+
+    // 대기열 단건 조회
+    @Query("SELECT w FROM Waitlist w "
+            + "WHERE w.classEntity.id = :classId AND w.user.id = :userId AND w.status = :status")
+    Optional<Waitlist> findByClassIdAndUserIdAndStatus(@Param("classId") Long classId,
+                                                      @Param("userId") Long userId,
+                                                      @Param("status") WaitlistStatus status);
+}

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/service/WaitlistService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/service/WaitlistService.java
@@ -15,12 +15,14 @@ import com.enrollment.domain.waitlist.repository.WaitlistRepository;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -117,10 +119,15 @@ public class WaitlistService {
                             .user(next.getUser())
                             .status(EnrollmentStatus.PENDING)
                             .enrolledAt(LocalDateTime.now())
+                            .expiresAt(Enrollment.defaultExpiresAt())
                             .build());
 
             // 대기열 승격
             next.promote(promoted.getId());
+
+            // 승격 알림 로그
+            log.info("[Waitlist] Promoted user={} to enrollment={} (expiresAt={})",
+                    next.getUser().getId(), promoted.getId(), promoted.getExpiresAt());
             break;
         }
     }

--- a/enrollment-api/src/main/java/com/enrollment/domain/waitlist/service/WaitlistService.java
+++ b/enrollment-api/src/main/java/com/enrollment/domain/waitlist/service/WaitlistService.java
@@ -1,0 +1,127 @@
+package com.enrollment.domain.waitlist.service;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.dto.WaitlistResponse;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.domain.waitlist.repository.WaitlistRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WaitlistService {
+
+    private final WaitlistRepository waitlistRepository;
+    private final EnrollmentRepository enrollmentRepository;
+    private final ClassRepository classRepository;
+    private final UserRepository userRepository;
+
+    // 대기열 등록
+    @Transactional
+    public WaitlistResponse register(Long userId, Long classId) {
+
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 강의 조회 (읽기 전용이라 락 불필요, uk_active_waitlist 유니크 인덱스로 중복 대기 차단)
+        ClassEntity classEntity = classRepository.findById(classId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+        // 강의 상태 검증
+        if (classEntity.getStatus() != ClassStatus.OPEN) {
+            throw new BusinessException(ErrorCode.WAITLIST_NOT_ALLOWED);
+        }
+
+        // 정원 여유 검증
+        if (classEntity.hasVacancy()) {
+            throw new BusinessException(ErrorCode.WAITLIST_NOT_ALLOWED);
+        }
+
+        // 활성 수강 신청 존재 여부 검증
+        if (enrollmentRepository.existsActiveByClassIdAndUserId(classId, userId)) {
+            throw new BusinessException(ErrorCode.ALREADY_ENROLLED);
+        }
+
+        // 대기열 중복 검증
+        if (waitlistRepository.existsByClassIdAndUserIdAndStatus(classId, userId, WaitlistStatus.WAITING)) {
+            throw new BusinessException(ErrorCode.ALREADY_IN_WAITLIST);
+        }
+
+        // 대기열 저장
+        return WaitlistResponse.from(waitlistRepository.save(
+                Waitlist.builder()
+                        .classEntity(classEntity)
+                        .user(user)
+                        .status(WaitlistStatus.WAITING)
+                        .build()));
+    }
+
+    // 대기열 철회
+    @Transactional
+    public void cancelWaitlist(Long userId, Long classId) {
+
+        // 대기열 조회
+        Waitlist waitlist = waitlistRepository
+                .findByClassIdAndUserIdAndStatus(classId, userId, WaitlistStatus.WAITING)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WAITLIST_NOT_FOUND));
+
+        // 대기열 소유자 검증
+        waitlist.validateOwner(userId);
+
+        // 대기열 취소
+        waitlist.cancel();
+    }
+
+    // 선두 자동 승격 (EnrollmentService.cancel 내부에서 호출, 같은 트랜잭션)
+    @Transactional
+    public void promoteNext(ClassEntity classEntity) {
+        while (true) {
+
+            // 선두 대기열 조회
+            Optional<Waitlist> found = waitlistRepository.findFirstWaitingForUpdate(classEntity.getId());
+            if (found.isEmpty()) {
+                return;
+            }
+            Waitlist next = found.get();
+
+            // 선두가 이미 활성 수강 신청 보유 시 skip
+            if (enrollmentRepository.existsActiveByClassIdAndUserId(
+                    classEntity.getId(), next.getUser().getId())) {
+                next.skip();
+                continue;
+            }
+
+            // 좌석 재차지
+            classEntity.incrementEnrolled();
+
+            // PENDING 수강 신청 생성
+            Enrollment promoted = enrollmentRepository.save(
+                    Enrollment.builder()
+                            .classEntity(classEntity)
+                            .user(next.getUser())
+                            .status(EnrollmentStatus.PENDING)
+                            .enrolledAt(LocalDateTime.now())
+                            .build());
+
+            // 대기열 승격
+            next.promote(promoted.getId());
+            break;
+        }
+    }
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/config/JpaAuditingConfig.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.enrollment.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/entity/BaseEntity.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.enrollment.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/enrollment-api/src/main/java/com/enrollment/global/error/GlobalExceptionHandler.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/GlobalExceptionHandler.java
@@ -7,8 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.Comparator;
 import java.util.stream.Collectors;
@@ -36,6 +38,24 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_INPUT.getHttpStatus())
                 .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, detail, request.getRequestURI()));
+    }
+
+    @ExceptionHandler({MissingRequestHeaderException.class, MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<ErrorResponse> handleMissingHeader(Exception e, HttpServletRequest request) {
+        log.warn("Bad request: {}, path={}", e.getMessage(), request.getRequestURI());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, e.getMessage(), request.getRequestURI()));
+    }
+
+    @ExceptionHandler(org.springframework.data.mapping.PropertyReferenceException.class)
+    public ResponseEntity<ErrorResponse> handlePropertyReference(
+            org.springframework.data.mapping.PropertyReferenceException e, HttpServletRequest request) {
+        log.warn("Invalid sort property: {}, path={}", e.getPropertyName(), request.getRequestURI());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT,
+                        "잘못된 정렬 필드: " + e.getPropertyName(), request.getRequestURI()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/enrollment-api/src/main/java/com/enrollment/global/error/GlobalExceptionHandler.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "권한이 없습니다"),
     NOT_COURSE_OWNER(HttpStatus.FORBIDDEN, "NOT_COURSE_OWNER", "해당 강의의 소유자가 아닙니다"),
+    FORBIDDEN_ROLE(HttpStatus.FORBIDDEN, "FORBIDDEN_ROLE", "해당 역할은 이 작업을 수행할 수 없습니다"),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다"),
     CLASS_NOT_FOUND(HttpStatus.NOT_FOUND, "CLASS_NOT_FOUND", "강의를 찾을 수 없습니다"),

--- a/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "권한이 없습니다"),
     NOT_COURSE_OWNER(HttpStatus.FORBIDDEN, "NOT_COURSE_OWNER", "해당 강의의 소유자가 아닙니다"),
+    NOT_ENROLLMENT_OWNER(HttpStatus.FORBIDDEN, "NOT_ENROLLMENT_OWNER", "본인의 수강 신청만 수정할 수 있습니다"),
     FORBIDDEN_ROLE(HttpStatus.FORBIDDEN, "FORBIDDEN_ROLE", "해당 역할은 이 작업을 수행할 수 없습니다"),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다"),

--- a/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
@@ -13,19 +13,23 @@ public enum ErrorCode {
     CANCEL_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "CANCEL_PERIOD_EXPIRED", "취소 가능 기간(7일)을 초과했습니다"),
     ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "ALREADY_CANCELLED", "이미 취소된 수강 신청입니다"),
     INVALID_STATE_TRANSITION(HttpStatus.BAD_REQUEST, "INVALID_STATE_TRANSITION", "허용되지 않은 상태 전이입니다"),
+    WAITLIST_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "WAITLIST_NOT_ALLOWED", "대기열에 등록할 수 없습니다"),
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다"),
 
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "권한이 없습니다"),
     NOT_COURSE_OWNER(HttpStatus.FORBIDDEN, "NOT_COURSE_OWNER", "해당 강의의 소유자가 아닙니다"),
     NOT_ENROLLMENT_OWNER(HttpStatus.FORBIDDEN, "NOT_ENROLLMENT_OWNER", "본인의 수강 신청만 수정할 수 있습니다"),
+    NOT_WAITLIST_OWNER(HttpStatus.FORBIDDEN, "NOT_WAITLIST_OWNER", "본인의 대기열만 철회할 수 있습니다"),
     FORBIDDEN_ROLE(HttpStatus.FORBIDDEN, "FORBIDDEN_ROLE", "해당 역할은 이 작업을 수행할 수 없습니다"),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다"),
     CLASS_NOT_FOUND(HttpStatus.NOT_FOUND, "CLASS_NOT_FOUND", "강의를 찾을 수 없습니다"),
     ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ENROLLMENT_NOT_FOUND", "수강 신청 내역을 찾을 수 없습니다"),
+    WAITLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "WAITLIST_NOT_FOUND", "대기열 정보를 찾을 수 없습니다"),
 
     ALREADY_ENROLLED(HttpStatus.CONFLICT, "ALREADY_ENROLLED", "이미 신청한 강의입니다"),
+    ALREADY_IN_WAITLIST(HttpStatus.CONFLICT, "ALREADY_IN_WAITLIST", "이미 대기열에 등록되어 있습니다"),
 
     LOCK_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "LOCK_TIMEOUT", "요청이 혼잡합니다. 잠시 후 다시 시도해주세요"),
 

--- a/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
+++ b/enrollment-api/src/main/java/com/enrollment/global/error/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "ALREADY_CANCELLED", "이미 취소된 수강 신청입니다"),
     INVALID_STATE_TRANSITION(HttpStatus.BAD_REQUEST, "INVALID_STATE_TRANSITION", "허용되지 않은 상태 전이입니다"),
     WAITLIST_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "WAITLIST_NOT_ALLOWED", "대기열에 등록할 수 없습니다"),
+    HOLD_EXPIRED(HttpStatus.BAD_REQUEST, "HOLD_EXPIRED", "결제 가능 시간이 초과되었습니다"),
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다"),
 

--- a/enrollment-api/src/main/resources/application.yml
+++ b/enrollment-api/src/main/resources/application.yml
@@ -4,6 +4,11 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME:liveklass}
     password: ${SPRING_DATASOURCE_PASSWORD:liveklass}
     driver-class-name: org.postgresql.Driver
+  data:
+    web:
+      pageable:
+        default-page-size: 20
+        max-page-size: 100
   jpa:
     hibernate:
       ddl-auto: validate

--- a/enrollment-api/src/main/resources/db/migration/V1__create_users_table.sql
+++ b/enrollment-api/src/main/resources/db/migration/V1__create_users_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE users (
+    user_id    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name       VARCHAR(50) NOT NULL,
+    role       VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    updated_at TIMESTAMP(6) NOT NULL
+);

--- a/enrollment-api/src/main/resources/db/migration/V2__create_classes_table.sql
+++ b/enrollment-api/src/main/resources/db/migration/V2__create_classes_table.sql
@@ -1,0 +1,23 @@
+CREATE TABLE classes (
+    class_id       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    created_by     BIGINT NOT NULL REFERENCES users(user_id),
+    title          VARCHAR(100) NOT NULL,
+    description    TEXT,
+    price          INTEGER NOT NULL,
+    capacity       INTEGER NOT NULL,
+    enrolled_count INTEGER NOT NULL DEFAULT 0,
+    start_date     DATE NOT NULL,
+    end_date       DATE NOT NULL,
+    status         VARCHAR(20) NOT NULL,
+    version        BIGINT NOT NULL DEFAULT 0,
+    created_at     TIMESTAMP(6) NOT NULL,
+    updated_at     TIMESTAMP(6) NOT NULL,
+    CONSTRAINT chk_capacity CHECK (capacity > 0),
+    CONSTRAINT chk_enrolled CHECK (enrolled_count >= 0 AND enrolled_count <= capacity),
+    CONSTRAINT chk_price CHECK (price >= 0),
+    CONSTRAINT chk_date_range CHECK (end_date > start_date)
+);
+
+CREATE INDEX idx_classes_status ON classes(status);
+CREATE INDEX idx_classes_created_by ON classes(created_by);
+CREATE INDEX idx_classes_created_by_status ON classes(created_by, status);

--- a/enrollment-api/src/main/resources/db/migration/V3__insert_seed_users.sql
+++ b/enrollment-api/src/main/resources/db/migration/V3__insert_seed_users.sql
@@ -1,0 +1,12 @@
+-- 과제 제출용 시드 유저: X-User-Id: 1 (CREATOR), X-User-Id: 2 (CLASSMATE)
+INSERT INTO users (user_id, name, role, created_at, updated_at)
+OVERRIDING SYSTEM VALUE
+VALUES (1, '시드 강사', 'CREATOR', NOW(), NOW()),
+       (2, '시드 수강생', 'CLASSMATE', NOW(), NOW())
+ON CONFLICT (user_id) DO NOTHING;
+
+-- IDENTITY 시퀀스를 현재 최대 user_id 이상으로 동기화 (이후 신규 유저 삽입 시 충돌 방지)
+SELECT setval(
+    pg_get_serial_sequence('users', 'user_id'),
+    GREATEST((SELECT COALESCE(MAX(user_id), 0) FROM users), 2)
+);

--- a/enrollment-api/src/main/resources/db/migration/V4__create_enrollments_table.sql
+++ b/enrollment-api/src/main/resources/db/migration/V4__create_enrollments_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE enrollments (
+    enrollment_id  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    class_id       BIGINT NOT NULL REFERENCES classes(class_id),
+    user_id        BIGINT NOT NULL REFERENCES users(user_id),
+    status         VARCHAR(20) NOT NULL,
+    enrolled_at    TIMESTAMP(6) NOT NULL,
+    confirmed_at   TIMESTAMP(6),
+    cancelled_at   TIMESTAMP(6),
+    created_at     TIMESTAMP(6) NOT NULL,
+    updated_at     TIMESTAMP(6) NOT NULL,
+    CONSTRAINT chk_enrollment_status CHECK (status IN ('PENDING', 'CONFIRMED', 'CANCELLED'))
+);
+
+CREATE INDEX idx_enrollments_user_id ON enrollments(user_id);
+CREATE INDEX idx_enrollments_class_id ON enrollments(class_id);
+CREATE UNIQUE INDEX uk_active_enrollment ON enrollments(class_id, user_id)
+    WHERE status IN ('PENDING', 'CONFIRMED');

--- a/enrollment-api/src/main/resources/db/migration/V5__create_payments_table.sql
+++ b/enrollment-api/src/main/resources/db/migration/V5__create_payments_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE payments (
+    payment_id     BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    enrollment_id  BIGINT NOT NULL REFERENCES enrollments(enrollment_id),
+    amount         INTEGER NOT NULL,
+    status         VARCHAR(20) NOT NULL,
+    paid_at        TIMESTAMP(6) NOT NULL,
+    created_at     TIMESTAMP(6) NOT NULL,
+    updated_at     TIMESTAMP(6) NOT NULL,
+    CONSTRAINT chk_payment_amount CHECK (amount >= 0),
+    CONSTRAINT chk_payment_status CHECK (status IN ('PAID', 'REFUNDED', 'FAILED'))
+);
+
+CREATE INDEX idx_payments_enrollment_id ON payments(enrollment_id);
+CREATE UNIQUE INDEX uk_payment_paid ON payments(enrollment_id) WHERE status = 'PAID';

--- a/enrollment-api/src/main/resources/db/migration/V6__create_waitlists_table.sql
+++ b/enrollment-api/src/main/resources/db/migration/V6__create_waitlists_table.sql
@@ -1,0 +1,31 @@
+CREATE TABLE waitlists (
+    waitlist_id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    class_id                BIGINT NOT NULL REFERENCES classes(class_id),
+    user_id                 BIGINT NOT NULL REFERENCES users(user_id),
+    status                  VARCHAR(20) NOT NULL,
+    promoted_enrollment_id  BIGINT REFERENCES enrollments(enrollment_id),
+    promoted_at             TIMESTAMP(6),
+    cancelled_at            TIMESTAMP(6),
+    created_at              TIMESTAMP(6) NOT NULL,
+    updated_at              TIMESTAMP(6) NOT NULL,
+    CONSTRAINT chk_waitlist_status CHECK (status IN ('WAITING', 'PROMOTED', 'CANCELLED')),
+    CONSTRAINT chk_waitlist_promotion CHECK (
+        (status = 'PROMOTED' AND promoted_enrollment_id IS NOT NULL AND promoted_at IS NOT NULL)
+        OR (status <> 'PROMOTED')
+    ),
+    CONSTRAINT chk_waitlist_cancelled CHECK (
+        (status = 'CANCELLED' AND cancelled_at IS NOT NULL)
+        OR (status <> 'CANCELLED' AND cancelled_at IS NULL)
+    )
+);
+
+CREATE INDEX idx_waitlists_class_id ON waitlists(class_id);
+CREATE INDEX idx_waitlists_user_id ON waitlists(user_id);
+
+-- 한 유저는 한 강의에 1 WAITING만 (CANCELLED 후 재대기 허용)
+CREATE UNIQUE INDEX uk_active_waitlist ON waitlists(class_id, user_id)
+    WHERE status = 'WAITING';
+
+-- FIFO 승격 + 동일 시각 타이브레이커
+CREATE INDEX idx_waitlist_fifo ON waitlists(class_id, created_at, waitlist_id)
+    WHERE status = 'WAITING';

--- a/enrollment-api/src/main/resources/db/migration/V7__add_enrollment_expires_at.sql
+++ b/enrollment-api/src/main/resources/db/migration/V7__add_enrollment_expires_at.sql
@@ -1,0 +1,5 @@
+ALTER TABLE enrollments ADD COLUMN expires_at TIMESTAMP(6);
+
+CREATE INDEX idx_enrollments_pending_expires
+    ON enrollments(expires_at)
+    WHERE status = 'PENDING';

--- a/enrollment-api/src/test/java/com/enrollment/EnrollmentApplicationTests.java
+++ b/enrollment-api/src/test/java/com/enrollment/EnrollmentApplicationTests.java
@@ -1,10 +1,11 @@
 package com.enrollment;
 
+import com.enrollment.support.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class EnrollmentApplicationTests {
+class EnrollmentApplicationTests extends AbstractIntegrationTest {
     @Test
     void contextLoads() {
     }

--- a/enrollment-api/src/test/java/com/enrollment/domain/classes/controller/ClassControllerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/classes/controller/ClassControllerTest.java
@@ -3,6 +3,8 @@ package com.enrollment.domain.classes.controller;
 import com.enrollment.domain.classes.dto.ClassResponse;
 import com.enrollment.domain.classes.entity.ClassStatus;
 import com.enrollment.domain.classes.service.ClassService;
+import com.enrollment.domain.enrollment.dto.EnrollmentWithUserResponse;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
 import com.enrollment.global.error.GlobalExceptionHandler;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
@@ -38,6 +40,8 @@ class ClassControllerTest {
     ObjectMapper objectMapper;
     @MockBean
     ClassService classService;
+    @MockBean
+    EnrollmentService enrollmentService;
 
     private static final LocalDateTime NOW = LocalDateTime.of(2025, 1, 1, 0, 0);
 
@@ -444,6 +448,48 @@ class ClassControllerTest {
                             .param("size", "20"))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+        }
+    }
+
+    @Nested
+    class GetClassEnrollments {
+
+        @Test
+        void 강사_본인_강의_수강생_목록_200() throws Exception {
+            EnrollmentWithUserResponse response = new EnrollmentWithUserResponse(
+                    100L, 2L, "student", "PENDING", NOW);
+            given(enrollmentService.getClassEnrollments(eq(1L), eq(1L), any()))
+                    .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+            mockMvc.perform(get("/classes/1/enrollments")
+                            .header("X-User-Id", 1L)
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].enrollmentId").value(100))
+                    .andExpect(jsonPath("$.content[0].userName").value("student"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            given(enrollmentService.getClassEnrollments(eq(999L), eq(1L), any()))
+                    .willThrow(new BusinessException(ErrorCode.NOT_COURSE_OWNER));
+
+            mockMvc.perform(get("/classes/1/enrollments")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_COURSE_OWNER"));
+        }
+
+        @Test
+        void 강의_미존재_시_404() throws Exception {
+            given(enrollmentService.getClassEnrollments(eq(1L), eq(999L), any()))
+                    .willThrow(new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+            mockMvc.perform(get("/classes/999/enrollments")
+                            .header("X-User-Id", 1L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
         }
     }
 }

--- a/enrollment-api/src/test/java/com/enrollment/domain/classes/controller/ClassControllerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/classes/controller/ClassControllerTest.java
@@ -1,0 +1,449 @@
+package com.enrollment.domain.classes.controller;
+
+import com.enrollment.domain.classes.dto.ClassResponse;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.service.ClassService;
+import com.enrollment.global.error.GlobalExceptionHandler;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ClassController.class)
+@Import(GlobalExceptionHandler.class)
+class ClassControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @MockBean
+    ClassService classService;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 1, 1, 0, 0);
+
+    private ClassResponse sampleResponse() {
+        return new ClassResponse(1L, "Java 기초", "설명", 10000, 30, 0,
+                LocalDate.of(2025, 3, 1), LocalDate.of(2025, 6, 30),
+                "DRAFT", "instructor", NOW);
+    }
+
+    @Nested
+    class CreateClass {
+
+        @Test
+        void 정상_생성_201() throws Exception {
+            given(classService.create(eq(1L), any())).willReturn(sampleResponse());
+
+            String body = """
+                    {
+                        "title": "Java 기초",
+                        "description": "설명",
+                        "price": 10000,
+                        "capacity": 30,
+                        "startDate": "2025-03-01",
+                        "endDate": "2025-06-30"
+                    }
+                    """;
+
+            mockMvc.perform(post("/classes")
+                            .header("X-User-Id", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.classId").value(1))
+                    .andExpect(jsonPath("$.title").value("Java 기초"))
+                    .andExpect(jsonPath("$.status").value("DRAFT"));
+        }
+
+        @Test
+        void CLASSMATE_등록_시_403() throws Exception {
+            given(classService.create(eq(2L), any()))
+                    .willThrow(new BusinessException(ErrorCode.FORBIDDEN_ROLE));
+
+            String body = """
+                    {
+                        "title": "Java 기초",
+                        "price": 10000,
+                        "capacity": 30,
+                        "startDate": "2025-03-01",
+                        "endDate": "2025-06-30"
+                    }
+                    """;
+
+            mockMvc.perform(post("/classes")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("FORBIDDEN_ROLE"));
+        }
+
+        @Test
+        void title_빈문자열_시_400() throws Exception {
+            String body = """
+                    {
+                        "title": "",
+                        "price": 10000,
+                        "capacity": 30,
+                        "startDate": "2025-03-01",
+                        "endDate": "2025-06-30"
+                    }
+                    """;
+
+            mockMvc.perform(post("/classes")
+                            .header("X-User-Id", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+
+        @Test
+        void price_음수_시_400() throws Exception {
+            String body = """
+                    {
+                        "title": "Java",
+                        "price": -1,
+                        "capacity": 30,
+                        "startDate": "2025-03-01",
+                        "endDate": "2025-06-30"
+                    }
+                    """;
+
+            mockMvc.perform(post("/classes")
+                            .header("X-User-Id", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void capacity_0_시_400() throws Exception {
+            String body = """
+                    {
+                        "title": "Java",
+                        "price": 10000,
+                        "capacity": 0,
+                        "startDate": "2025-03-01",
+                        "endDate": "2025-06-30"
+                    }
+                    """;
+
+            mockMvc.perform(post("/classes")
+                            .header("X-User-Id", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+
+        @Test
+        void title_누락_시_400() throws Exception {
+            String body = """
+                    {
+                        "price": 10000,
+                        "capacity": 30,
+                        "startDate": "2025-03-01",
+                        "endDate": "2025-06-30"
+                    }
+                    """;
+
+            mockMvc.perform(post("/classes")
+                            .header("X-User-Id", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+
+        @Test
+        void X_User_Id_헤더_누락_시_400() throws Exception {
+            String body = """
+                    {
+                        "title": "Java 기초",
+                        "price": 10000,
+                        "capacity": 30,
+                        "startDate": "2025-03-01",
+                        "endDate": "2025-06-30"
+                    }
+                    """;
+
+            mockMvc.perform(post("/classes")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+    }
+
+    @Nested
+    class UpdateClass {
+
+        @Test
+        void 정상_수정_200() throws Exception {
+            ClassResponse updated = new ClassResponse(1L, "새 제목", "설명", 10000, 30, 0,
+                    LocalDate.of(2025, 3, 1), LocalDate.of(2025, 6, 30),
+                    "DRAFT", "instructor", NOW);
+            given(classService.update(eq(1L), eq(1L), any())).willReturn(updated);
+
+            String body = """
+                    {"title": "새 제목"}
+                    """;
+
+            mockMvc.perform(patch("/classes/1")
+                            .header("X-User-Id", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.title").value("새 제목"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            given(classService.update(eq(999L), eq(1L), any()))
+                    .willThrow(new BusinessException(ErrorCode.NOT_COURSE_OWNER));
+
+            String body = """
+                    {"title": "새 제목"}
+                    """;
+
+            mockMvc.perform(patch("/classes/1")
+                            .header("X-User-Id", 999L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_COURSE_OWNER"));
+        }
+
+        @Test
+        void OPEN_상태에서_update_시_400() throws Exception {
+            given(classService.update(eq(1L), eq(1L), any()))
+                    .willThrow(new BusinessException(ErrorCode.INVALID_STATE_TRANSITION));
+
+            String body = """
+                    {"title": "새 제목"}
+                    """;
+
+            mockMvc.perform(patch("/classes/1")
+                            .header("X-User-Id", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+        }
+    }
+
+    @Nested
+    class PublishClass {
+
+        @Test
+        void 정상_publish_200() throws Exception {
+            ClassResponse published = new ClassResponse(1L, "Java 기초", "설명", 10000, 30, 0,
+                    LocalDate.of(2025, 3, 1), LocalDate.of(2025, 6, 30),
+                    "OPEN", "instructor", NOW);
+            given(classService.publish(1L, 1L)).willReturn(published);
+
+            mockMvc.perform(patch("/classes/1/publish")
+                            .header("X-User-Id", 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("OPEN"));
+        }
+
+        @Test
+        void 강의_미존재_시_404() throws Exception {
+            given(classService.publish(1L, 999L))
+                    .willThrow(new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+            mockMvc.perform(patch("/classes/999/publish")
+                            .header("X-User-Id", 1L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
+        }
+
+        @Test
+        void OPEN_상태에서_publish_시_400() throws Exception {
+            given(classService.publish(1L, 1L))
+                    .willThrow(new BusinessException(ErrorCode.INVALID_STATE_TRANSITION));
+
+            mockMvc.perform(patch("/classes/1/publish")
+                            .header("X-User-Id", 1L))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            given(classService.publish(999L, 1L))
+                    .willThrow(new BusinessException(ErrorCode.NOT_COURSE_OWNER));
+
+            mockMvc.perform(patch("/classes/1/publish")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_COURSE_OWNER"));
+        }
+    }
+
+    @Nested
+    class CloseClass {
+
+        @Test
+        void 정상_close_200() throws Exception {
+            ClassResponse closed = new ClassResponse(1L, "Java 기초", "설명", 10000, 30, 0,
+                    LocalDate.of(2025, 3, 1), LocalDate.of(2025, 6, 30),
+                    "CLOSED", "instructor", NOW);
+            given(classService.close(1L, 1L)).willReturn(closed);
+
+            mockMvc.perform(patch("/classes/1/close")
+                            .header("X-User-Id", 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("CLOSED"));
+        }
+
+        @Test
+        void DRAFT_상태에서_close_시_400() throws Exception {
+            given(classService.close(1L, 1L))
+                    .willThrow(new BusinessException(ErrorCode.INVALID_STATE_TRANSITION));
+
+            mockMvc.perform(patch("/classes/1/close")
+                            .header("X-User-Id", 1L))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            given(classService.close(999L, 1L))
+                    .willThrow(new BusinessException(ErrorCode.NOT_COURSE_OWNER));
+
+            mockMvc.perform(patch("/classes/1/close")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_COURSE_OWNER"));
+        }
+    }
+
+    @Nested
+    class GetClasses {
+
+        @Test
+        void status_필터_목록_조회_200() throws Exception {
+            ClassResponse response = new ClassResponse(1L, "Java 기초", "설명", 10000, 30, 0,
+                    LocalDate.of(2025, 3, 1), LocalDate.of(2025, 6, 30),
+                    "OPEN", "instructor", NOW);
+            given(classService.getClasses(eq(ClassStatus.OPEN), any()))
+                    .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+            mockMvc.perform(get("/classes")
+                            .param("status", "OPEN")
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].status").value("OPEN"))
+                    .andExpect(jsonPath("$.totalElements").value(1));
+        }
+
+        @Test
+        void 잘못된_sort_필드_400_INVALID_INPUT() throws Exception {
+            given(classService.getClasses(eq(ClassStatus.OPEN), any()))
+                    .willThrow(new org.springframework.data.mapping.PropertyReferenceException(
+                            "nonexistent",
+                            org.springframework.data.util.TypeInformation.of(Object.class),
+                            java.util.Collections.emptyList()));
+
+            mockMvc.perform(get("/classes")
+                            .param("status", "OPEN")
+                            .param("sort", "nonexistent"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+
+        @Test
+        void status_누락_시_default_OPEN() throws Exception {
+            ClassResponse response = new ClassResponse(1L, "Java 기초", "설명", 10000, 30, 0,
+                    LocalDate.of(2025, 3, 1), LocalDate.of(2025, 6, 30),
+                    "OPEN", "instructor", NOW);
+            given(classService.getClasses(eq(ClassStatus.OPEN), any()))
+                    .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+            mockMvc.perform(get("/classes")
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].status").value("OPEN"));
+        }
+    }
+
+    @Nested
+    class GetClassById {
+
+        @Test
+        void 단건_조회_200() throws Exception {
+            given(classService.getClass(1L)).willReturn(sampleResponse());
+
+            mockMvc.perform(get("/classes/1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.classId").value(1))
+                    .andExpect(jsonPath("$.title").value("Java 기초"));
+        }
+
+        @Test
+        void 미존재_시_404() throws Exception {
+            given(classService.getClass(999L))
+                    .willThrow(new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+            mockMvc.perform(get("/classes/999"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
+        }
+    }
+
+    @Nested
+    class GetMyClasses {
+
+        @Test
+        void 내_강의_목록_200() throws Exception {
+            given(classService.getMyClasses(eq(1L), any()))
+                    .willReturn(new PageImpl<>(List.of(sampleResponse()), PageRequest.of(0, 20), 1));
+
+            mockMvc.perform(get("/classes/me")
+                            .header("X-User-Id", 1L)
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].classId").value(1));
+        }
+
+        @Test
+        void 사용자_미존재_시_404() throws Exception {
+            given(classService.getMyClasses(eq(999L), any()))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            mockMvc.perform(get("/classes/me")
+                            .header("X-User-Id", 999L)
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+        }
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/classes/entity/ClassEntityTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/classes/entity/ClassEntityTest.java
@@ -244,6 +244,71 @@ class ClassEntityTest {
         }
     }
 
+    @Nested
+    class IncrementEnrolled {
+
+        @Test
+        void 정상_증가() {
+            ClassEntity entity = validDraft();
+            entity.incrementEnrolled();
+            assertThat(entity.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 정원_도달_시_CAPACITY_EXCEEDED_예외() {
+            ClassEntity entity = ClassEntity.builder()
+                    .createdBy(owner)
+                    .title("Java 기초").description("설명")
+                    .price(10000).capacity(2).enrolledCount(2)
+                    .startDate(LocalDate.of(2025, 3, 1))
+                    .endDate(LocalDate.of(2025, 6, 30))
+                    .status(ClassStatus.OPEN).build();
+            assertThatThrownBy(entity::incrementEnrolled)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CAPACITY_EXCEEDED));
+        }
+
+        @Test
+        void 정원_마지막_자리까지_증가_가능() {
+            ClassEntity entity = ClassEntity.builder()
+                    .createdBy(owner)
+                    .title("Java 기초").description("설명")
+                    .price(10000).capacity(2).enrolledCount(1)
+                    .startDate(LocalDate.of(2025, 3, 1))
+                    .endDate(LocalDate.of(2025, 6, 30))
+                    .status(ClassStatus.OPEN).build();
+            entity.incrementEnrolled();
+            assertThat(entity.getEnrolledCount()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class DecrementEnrolled {
+
+        @Test
+        void 정상_감소() {
+            ClassEntity entity = ClassEntity.builder()
+                    .createdBy(owner)
+                    .title("Java 기초").description("설명")
+                    .price(10000).capacity(30).enrolledCount(5)
+                    .startDate(LocalDate.of(2025, 3, 1))
+                    .endDate(LocalDate.of(2025, 6, 30))
+                    .status(ClassStatus.OPEN).build();
+            entity.decrementEnrolled();
+            assertThat(entity.getEnrolledCount()).isEqualTo(4);
+        }
+
+        @Test
+        void enrolledCount_0일_때_감소_시_INVALID_INPUT_예외() {
+            ClassEntity entity = validDraft();
+            assertThatThrownBy(entity::decrementEnrolled)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+    }
+
     private void setId(Object obj, Long id) throws Exception {
         Field field = obj.getClass().getDeclaredField("id");
         field.setAccessible(true);

--- a/enrollment-api/src/test/java/com/enrollment/domain/classes/entity/ClassEntityTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/classes/entity/ClassEntityTest.java
@@ -1,0 +1,252 @@
+package com.enrollment.domain.classes.entity;
+
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ClassEntityTest {
+
+    private User owner;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        owner = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(owner, 1L);
+    }
+
+    private ClassEntity validDraft() {
+        return ClassEntity.builder()
+                .createdBy(owner)
+                .title("Java 기초")
+                .description("자바 기초 강의")
+                .price(10000)
+                .capacity(30)
+                .enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT)
+                .build();
+    }
+
+    private ClassEntity openClass() {
+        ClassEntity entity = validDraft();
+        entity.publish();
+        return entity;
+    }
+
+    @Nested
+    class Publish {
+
+        @Test
+        void DRAFT_상태에서_publish_성공() {
+            ClassEntity entity = validDraft();
+            entity.publish();
+            assertThat(entity.getStatus()).isEqualTo(ClassStatus.OPEN);
+        }
+
+        @Test
+        void OPEN_상태에서_publish_실패() {
+            ClassEntity entity = openClass();
+            assertThatThrownBy(entity::publish)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void endDate가_startDate_이전이면_publish_실패() throws Exception {
+            // Build entity with inverted dates via reflection to bypass update() validation
+            ClassEntity entity = ClassEntity.builder()
+                    .createdBy(owner)
+                    .title("Java 기초")
+                    .description("자바 기초 강의")
+                    .price(10000)
+                    .capacity(30)
+                    .enrolledCount(0)
+                    .startDate(LocalDate.of(2025, 6, 30))
+                    .endDate(LocalDate.of(2025, 3, 1))
+                    .status(ClassStatus.DRAFT)
+                    .build();
+            assertThatThrownBy(entity::publish)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+
+        @Test
+        void startDate_equals_endDate_publish_실패() throws Exception {
+            // Build entity with equal dates via builder to bypass update() validation
+            ClassEntity entity = ClassEntity.builder()
+                    .createdBy(owner)
+                    .title("Java 기초")
+                    .description("자바 기초 강의")
+                    .price(10000)
+                    .capacity(30)
+                    .enrolledCount(0)
+                    .startDate(LocalDate.of(2025, 6, 30))
+                    .endDate(LocalDate.of(2025, 6, 30))
+                    .status(ClassStatus.DRAFT)
+                    .build();
+            assertThatThrownBy(entity::publish)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+    }
+
+    @Nested
+    class Close {
+
+        @Test
+        void OPEN_상태에서_close_성공() {
+            ClassEntity entity = openClass();
+            entity.close();
+            assertThat(entity.getStatus()).isEqualTo(ClassStatus.CLOSED);
+        }
+
+        @Test
+        void DRAFT_상태에서_close_실패() {
+            ClassEntity entity = validDraft();
+            assertThatThrownBy(entity::close)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void DRAFT_상태에서_전체_필드_수정_성공() {
+            ClassEntity entity = validDraft();
+            entity.update("새 제목", "새 설명", 20000, 50,
+                    LocalDate.of(2025, 4, 1), LocalDate.of(2025, 7, 31));
+            assertThat(entity.getTitle()).isEqualTo("새 제목");
+            assertThat(entity.getDescription()).isEqualTo("새 설명");
+            assertThat(entity.getPrice()).isEqualTo(20000);
+            assertThat(entity.getCapacity()).isEqualTo(50);
+            assertThat(entity.getStartDate()).isEqualTo(LocalDate.of(2025, 4, 1));
+            assertThat(entity.getEndDate()).isEqualTo(LocalDate.of(2025, 7, 31));
+        }
+
+        @Test
+        void null_필드는_기존값_유지() {
+            ClassEntity entity = validDraft();
+            entity.update(null, null, null, null, null, null);
+            assertThat(entity.getTitle()).isEqualTo("Java 기초");
+            assertThat(entity.getPrice()).isEqualTo(10000);
+        }
+
+        @Test
+        void OPEN_상태에서_update_실패() {
+            ClassEntity entity = openClass();
+            assertThatThrownBy(() -> entity.update("새 제목", null, null, null, null, null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void update_시_음수_price_INVALID_INPUT_예외() {
+            ClassEntity entity = validDraft();
+            assertThatThrownBy(() -> entity.update(null, null, -1, null, null, null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+
+        @Test
+        void update_시_0이하_capacity_INVALID_INPUT_예외() {
+            ClassEntity entity = validDraft();
+            assertThatThrownBy(() -> entity.update(null, null, null, 0, null, null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+
+        @Test
+        void update_시_시작일_종료일_이후면_INVALID_INPUT_예외() {
+            ClassEntity entity = validDraft();
+            assertThatThrownBy(() -> entity.update(null, null, null, null,
+                    LocalDate.of(2025, 7, 1), LocalDate.of(2025, 3, 1)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+
+        @Test
+        void update_시_startDate만_갱신해_endDate_이전이_되면_INVALID_INPUT_예외() {
+            // entity has endDate=2025-06-30; update startDate=2025-07-01 → startDate > endDate
+            ClassEntity entity = validDraft(); // endDate = 2025-06-30
+            assertThatThrownBy(() -> entity.update(null, null, null, null,
+                    LocalDate.of(2025, 7, 1), null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+
+        @Test
+        void price_0_update_성공() {
+            ClassEntity entity = validDraft();
+            entity.update(null, null, 0, null, null, null);
+            assertThat(entity.getPrice()).isEqualTo(0);
+        }
+
+        @Test
+        void capacity_1_update_성공() {
+            ClassEntity entity = validDraft();
+            entity.update(null, null, null, 1, null, null);
+            assertThat(entity.getCapacity()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    class ValidateOwner {
+
+        @Test
+        void 소유자_일치_시_예외_없음() {
+            ClassEntity entity = validDraft();
+            entity.validateOwner(1L);
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_COURSE_OWNER_예외() {
+            ClassEntity entity = validDraft();
+            assertThatThrownBy(() -> entity.validateOwner(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_COURSE_OWNER));
+        }
+
+        @Test
+        void createdBy_null_시_NOT_COURSE_OWNER() throws Exception {
+            ClassEntity entity = validDraft();
+            // Use reflection to set createdBy to null (bypassing builder)
+            Field createdByField = ClassEntity.class.getDeclaredField("createdBy");
+            createdByField.setAccessible(true);
+            createdByField.set(entity, null);
+
+            assertThatThrownBy(() -> entity.validateOwner(1L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_COURSE_OWNER));
+        }
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/classes/entity/ClassStatusTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/classes/entity/ClassStatusTest.java
@@ -1,0 +1,41 @@
+package com.enrollment.domain.classes.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClassStatusTest {
+
+    @Test
+    void DRAFT에서_OPEN으로_전이_가능() {
+        assertThat(ClassStatus.DRAFT.canTransitionTo(ClassStatus.OPEN)).isTrue();
+    }
+
+    @Test
+    void OPEN에서_CLOSED로_전이_가능() {
+        assertThat(ClassStatus.OPEN.canTransitionTo(ClassStatus.CLOSED)).isTrue();
+    }
+
+    @Test
+    void DRAFT에서_CLOSED로_전이_불가() {
+        assertThat(ClassStatus.DRAFT.canTransitionTo(ClassStatus.CLOSED)).isFalse();
+    }
+
+    @Test
+    void OPEN에서_DRAFT로_전이_불가() {
+        assertThat(ClassStatus.OPEN.canTransitionTo(ClassStatus.DRAFT)).isFalse();
+    }
+
+    @Test
+    void CLOSED에서_어디로도_전이_불가() {
+        assertThat(ClassStatus.CLOSED.canTransitionTo(ClassStatus.DRAFT)).isFalse();
+        assertThat(ClassStatus.CLOSED.canTransitionTo(ClassStatus.OPEN)).isFalse();
+    }
+
+    @Test
+    void 같은_상태로_전이_불가() {
+        assertThat(ClassStatus.DRAFT.canTransitionTo(ClassStatus.DRAFT)).isFalse();
+        assertThat(ClassStatus.OPEN.canTransitionTo(ClassStatus.OPEN)).isFalse();
+        assertThat(ClassStatus.CLOSED.canTransitionTo(ClassStatus.CLOSED)).isFalse();
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/classes/repository/ClassRepositoryTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/classes/repository/ClassRepositoryTest.java
@@ -1,0 +1,154 @@
+package com.enrollment.domain.classes.repository;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.config.JpaAuditingConfig;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Import(JpaAuditingConfig.class)
+class ClassRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    TestEntityManager em;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+
+    private User creator;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build()
+        );
+    }
+
+    private ClassEntity buildClass(ClassStatus status) {
+        return ClassEntity.builder()
+                .createdBy(creator)
+                .title("Test Class")
+                .description("desc")
+                .price(10000)
+                .capacity(30)
+                .enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(status)
+                .build();
+    }
+
+    @Test
+    void save_시_id_자동_생성_및_auditing() {
+        ClassEntity saved = classRepository.saveAndFlush(buildClass(ClassStatus.DRAFT));
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void findById_왕복() {
+        Long id = classRepository.saveAndFlush(buildClass(ClassStatus.DRAFT)).getId();
+        em.clear();
+        ClassEntity found = classRepository.findById(id).orElseThrow();
+        assertThat(found.getTitle()).isEqualTo("Test Class");
+        assertThat(found.getStatus()).isEqualTo(ClassStatus.DRAFT);
+    }
+
+    @Test
+    void findByIdForUpdate_비관적_잠금_조회() {
+        Long id = classRepository.saveAndFlush(buildClass(ClassStatus.OPEN)).getId();
+        em.clear();
+        Optional<ClassEntity> found = classRepository.findByIdForUpdate(id);
+        assertThat(found).isPresent();
+        assertThat(found.get().getStatus()).isEqualTo(ClassStatus.OPEN);
+        // JOIN FETCH must load createdBy eagerly — no LazyInitializationException
+        assertThat(found.get().getCreatedBy().getName()).isEqualTo("instructor");
+    }
+
+    @Test
+    void findWithCreatorById_createdBy_즉시_로딩_확인() {
+        Long id = classRepository.saveAndFlush(buildClass(ClassStatus.DRAFT)).getId();
+        em.clear();
+        Optional<ClassEntity> found = classRepository.findWithCreatorById(id);
+        assertThat(found).isPresent();
+        // EntityGraph must load createdBy eagerly — no LazyInitializationException
+        assertThat(found.get().getCreatedBy().getName()).isEqualTo("instructor");
+    }
+
+    @Test
+    void findWithCreatorById_미존재시_empty() {
+        Optional<ClassEntity> found = classRepository.findWithCreatorById(9999L);
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void findByStatus_필터링() {
+        classRepository.saveAndFlush(buildClass(ClassStatus.DRAFT));
+        classRepository.saveAndFlush(buildClass(ClassStatus.OPEN));
+        classRepository.saveAndFlush(buildClass(ClassStatus.OPEN));
+        em.clear();
+
+        Page<ClassEntity> openClasses = classRepository.findByStatus(ClassStatus.OPEN, PageRequest.of(0, 10));
+        assertThat(openClasses.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    void findByStatus_createdBy_즉시_로딩_확인() {
+        classRepository.saveAndFlush(buildClass(ClassStatus.OPEN));
+        em.clear();
+
+        Page<ClassEntity> result = classRepository.findByStatus(ClassStatus.OPEN, PageRequest.of(0, 10));
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        // LazyInitializationException 없이 createdBy.getName() 접근 가능해야 함
+        assertThat(result.getContent().get(0).getCreatedBy().getName()).isEqualTo("instructor");
+    }
+
+    @Test
+    void findByCreatedById_createdBy_즉시_로딩_확인() {
+        classRepository.saveAndFlush(buildClass(ClassStatus.DRAFT));
+        em.clear();
+
+        Page<ClassEntity> result = classRepository.findByCreatedById(creator.getId(), PageRequest.of(0, 10));
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getCreatedBy().getName()).isEqualTo("instructor");
+    }
+
+    @Test
+    void findByCreatedById_내_강의_조회() {
+        User other = userRepository.saveAndFlush(
+                User.builder().name("other").role(UserRole.CREATOR).build()
+        );
+        classRepository.saveAndFlush(buildClass(ClassStatus.DRAFT));
+        classRepository.saveAndFlush(ClassEntity.builder()
+                .createdBy(other).title("Other Class").description("desc")
+                .price(5000).capacity(20).enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1)).endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build());
+        em.clear();
+
+        Page<ClassEntity> myClasses = classRepository.findByCreatedById(creator.getId(), PageRequest.of(0, 10));
+        assertThat(myClasses.getTotalElements()).isEqualTo(1);
+        assertThat(myClasses.getContent().get(0).getTitle()).isEqualTo("Test Class");
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/classes/service/ClassServiceTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/classes/service/ClassServiceTest.java
@@ -1,0 +1,371 @@
+package com.enrollment.domain.classes.service;
+
+import com.enrollment.domain.classes.dto.ClassCreateRequest;
+import com.enrollment.domain.classes.dto.ClassResponse;
+import com.enrollment.domain.classes.dto.ClassUpdateRequest;
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ClassServiceTest {
+
+    @Mock
+    ClassRepository classRepository;
+    @Mock
+    UserRepository userRepository;
+    @InjectMocks
+    ClassService classService;
+
+    private User creator;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+    }
+
+    private ClassEntity draftEntity() throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초")
+                .description("설명")
+                .price(10000)
+                .capacity(30)
+                .enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT)
+                .build();
+        setId(entity, 10L);
+        return entity;
+    }
+
+    private ClassEntity openEntity() throws Exception {
+        ClassEntity entity = draftEntity();
+        entity.publish();
+        return entity;
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void 정상_생성() {
+            ClassCreateRequest request = new ClassCreateRequest(
+                    "Java 기초", "설명", 10000, 30,
+                    LocalDate.of(2025, 3, 1), LocalDate.of(2025, 6, 30));
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(creator));
+            given(classRepository.save(any(ClassEntity.class))).willAnswer(inv -> {
+                ClassEntity saved = inv.getArgument(0);
+                try { setId(saved, 10L); } catch (Exception ignored) {}
+                return saved;
+            });
+
+            ArgumentCaptor<ClassEntity> captor = ArgumentCaptor.forClass(ClassEntity.class);
+
+            ClassResponse response = classService.create(1L, request);
+
+            verify(classRepository).save(captor.capture());
+            ClassEntity saved = captor.getValue();
+            assertThat(saved.getStatus()).isEqualTo(ClassStatus.DRAFT);
+            assertThat(saved.getEnrolledCount()).isEqualTo(0);
+            assertThat(saved.getCreatedBy()).isEqualTo(creator);
+
+            assertThat(response.classId()).isEqualTo(10L);
+            assertThat(response.title()).isEqualTo("Java 기초");
+            assertThat(response.price()).isEqualTo(10000);
+            assertThat(response.capacity()).isEqualTo(30);
+            assertThat(response.enrolledCount()).isEqualTo(0);
+            assertThat(response.startDate()).isEqualTo(LocalDate.of(2025, 3, 1));
+            assertThat(response.endDate()).isEqualTo(LocalDate.of(2025, 6, 30));
+            assertThat(response.status()).isEqualTo("DRAFT");
+            assertThat(response.creatorName()).isEqualTo("instructor");
+        }
+
+        @Test
+        void CLASSMATE가_강의_등록_시_FORBIDDEN_ROLE_예외() throws Exception {
+            User classmate = User.builder().name("학생").role(UserRole.CLASSMATE).build();
+            setId(classmate, 2L);
+            ClassCreateRequest request = new ClassCreateRequest(
+                    "Java 기초", "설명", 10000, 30,
+                    LocalDate.of(2025, 3, 1), LocalDate.of(2025, 6, 30));
+
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+
+            assertThatThrownBy(() -> classService.create(2L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.FORBIDDEN_ROLE));
+        }
+
+        @Test
+        void 존재하지_않는_사용자면_USER_NOT_FOUND() {
+            ClassCreateRequest request = new ClassCreateRequest(
+                    "Java 기초", "설명", 10000, 30,
+                    LocalDate.of(2025, 3, 1), LocalDate.of(2025, 6, 30));
+
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> classService.create(999L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+
+        @Test
+        void endDate가_startDate보다_이전이면_INVALID_INPUT() {
+            ClassCreateRequest request = new ClassCreateRequest(
+                    "Java 기초", "설명", 10000, 30,
+                    LocalDate.of(2025, 6, 30), LocalDate.of(2025, 3, 1));
+
+            assertThatThrownBy(() -> classService.create(1L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+
+        @Test
+        void endDate가_startDate와_같으면_INVALID_INPUT() {
+            ClassCreateRequest request = new ClassCreateRequest(
+                    "Java 기초", "설명", 10000, 30,
+                    LocalDate.of(2025, 3, 1), LocalDate.of(2025, 3, 1));
+
+            assertThatThrownBy(() -> classService.create(1L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void DRAFT_상태에서_수정_성공() throws Exception {
+            ClassEntity entity = draftEntity();
+            ClassUpdateRequest request = new ClassUpdateRequest(
+                    "새 제목", null, null, null, null, null);
+
+            given(classRepository.findWithCreatorById(10L)).willReturn(Optional.of(entity));
+
+            ClassResponse response = classService.update(1L, 10L, request);
+            assertThat(response.title()).isEqualTo("새 제목");
+        }
+
+        @Test
+        void 존재하지_않는_강의면_CLASS_NOT_FOUND() {
+            given(classRepository.findWithCreatorById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> classService.update(1L, 999L,
+                    new ClassUpdateRequest("t", null, null, null, null, null)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CLASS_NOT_FOUND));
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_COURSE_OWNER() throws Exception {
+            ClassEntity entity = draftEntity();
+            given(classRepository.findWithCreatorById(10L)).willReturn(Optional.of(entity));
+
+            assertThatThrownBy(() -> classService.update(999L, 10L,
+                    new ClassUpdateRequest("t", null, null, null, null, null)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_COURSE_OWNER));
+        }
+
+        @Test
+        void OPEN_상태에서_update_시_INVALID_STATE_TRANSITION() throws Exception {
+            ClassEntity entity = openEntity();
+            given(classRepository.findWithCreatorById(10L)).willReturn(Optional.of(entity));
+
+            assertThatThrownBy(() -> classService.update(1L, 10L,
+                    new ClassUpdateRequest("새 제목", null, null, null, null, null)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class Publish {
+
+        @Test
+        void 정상_publish() throws Exception {
+            ClassEntity entity = draftEntity();
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(entity));
+
+            ClassResponse response = classService.publish(1L, 10L);
+            assertThat(response.status()).isEqualTo("OPEN");
+        }
+
+        @Test
+        void 소유자_불일치_시_실패() throws Exception {
+            ClassEntity entity = draftEntity();
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(entity));
+
+            assertThatThrownBy(() -> classService.publish(999L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_COURSE_OWNER));
+        }
+
+        @Test
+        void OPEN_상태에서_publish_시_INVALID_STATE_TRANSITION() throws Exception {
+            ClassEntity entity = openEntity();
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(entity));
+
+            assertThatThrownBy(() -> classService.publish(1L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class CloseTest {
+
+        @Test
+        void 정상_close() throws Exception {
+            ClassEntity entity = openEntity();
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(entity));
+
+            ClassResponse response = classService.close(1L, 10L);
+            assertThat(response.status()).isEqualTo("CLOSED");
+        }
+
+        @Test
+        void 존재하지_않는_강의면_CLASS_NOT_FOUND() {
+            given(classRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> classService.close(1L, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CLASS_NOT_FOUND));
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_COURSE_OWNER() throws Exception {
+            ClassEntity entity = openEntity();
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(entity));
+
+            assertThatThrownBy(() -> classService.close(999L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_COURSE_OWNER));
+        }
+
+        @Test
+        void DRAFT_상태에서_close_시_INVALID_STATE_TRANSITION() throws Exception {
+            ClassEntity entity = draftEntity();
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(entity));
+
+            assertThatThrownBy(() -> classService.close(1L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class GetClasses {
+
+        @Test
+        void status별_목록_조회() throws Exception {
+            ClassEntity entity = openEntity();
+            Page<ClassEntity> page = new PageImpl<>(List.of(entity));
+            given(classRepository.findByStatus(ClassStatus.OPEN, PageRequest.of(0, 20)))
+                    .willReturn(page);
+
+            Page<ClassResponse> result = classService.getClasses(ClassStatus.OPEN, PageRequest.of(0, 20));
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).status()).isEqualTo("OPEN");
+        }
+    }
+
+    @Nested
+    class GetClass {
+
+        @Test
+        void 단건_조회_성공() throws Exception {
+            ClassEntity entity = draftEntity();
+            given(classRepository.findWithCreatorById(10L)).willReturn(Optional.of(entity));
+
+            ClassResponse response = classService.getClass(10L);
+            assertThat(response.classId()).isEqualTo(10L);
+        }
+
+        @Test
+        void 존재하지_않는_강의면_CLASS_NOT_FOUND() {
+            given(classRepository.findWithCreatorById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> classService.getClass(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CLASS_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    class GetMyClasses {
+
+        @Test
+        void 내_강의_목록_조회() throws Exception {
+            ClassEntity entity = draftEntity();
+            Page<ClassEntity> page = new PageImpl<>(List.of(entity));
+            Pageable pageable = PageRequest.of(0, 20);
+            given(userRepository.existsById(1L)).willReturn(true);
+            given(classRepository.findByCreatedById(1L, pageable)).willReturn(page);
+
+            Page<ClassResponse> result = classService.getMyClasses(1L, pageable);
+            assertThat(result.getTotalElements()).isEqualTo(1);
+        }
+
+        @Test
+        void 사용자_미존재_시_USER_NOT_FOUND() {
+            given(userRepository.existsById(999L)).willReturn(false);
+
+            assertThatThrownBy(() -> classService.getMyClasses(999L, PageRequest.of(0, 20)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/EnrollmentConcurrencyTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/EnrollmentConcurrencyTest.java
@@ -1,0 +1,112 @@
+package com.enrollment.domain.enrollment;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class EnrollmentConcurrencyTest extends AbstractIntegrationTest {
+
+    @Autowired
+    EnrollmentService enrollmentService;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    EnrollmentRepository enrollmentRepository;
+
+    private Long classId;
+    private List<Long> classmateIds;
+
+    @BeforeEach
+    void setUp() {
+        User creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build());
+
+        // 10명의 학생이 동시에 같은 강의에 신청 — 중복 방지 인덱스 우회를 위해 유저는 서로 다름
+        classmateIds = IntStream.range(0, 10)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("학생" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("마감_임박_강의").description("정원 1석")
+                        .price(10000).capacity(1).enrolledCount(0)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+
+        classId = openClass.getId();
+    }
+
+    @Test
+    void 정원_1명_강의에_10명이_동시_신청_시_정확히_1명만_성공() throws Exception {
+        int threadCount = classmateIds.size();
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+        for (Long classmateId : classmateIds) {
+            pool.submit(() -> {
+                try {
+                    startLatch.await();
+                    enrollmentService.enroll(classmateId, new EnrollmentCreateRequest(classId));
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    // BusinessException(CAPACITY_EXCEEDED) + 락/트랜잭션 예외 모두 실패로 집계
+                    failCount.incrementAndGet();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        boolean finished = doneLatch.await(15, TimeUnit.SECONDS);
+        pool.shutdown();
+
+        assertThat(finished).isTrue();
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(threadCount - 1);
+
+        ClassEntity finalClass = classRepository.findById(classId).orElseThrow();
+        assertThat(finalClass.getEnrolledCount()).isEqualTo(1);
+
+        long activeEnrollments = enrollmentRepository.findByClassEntityId(classId, PageRequest.of(0, 20))
+                .stream()
+                .filter(e -> e.getStatus() != EnrollmentStatus.CANCELLED)
+                .count();
+        assertThat(activeEnrollments).isEqualTo(1);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/controller/EnrollmentControllerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/controller/EnrollmentControllerTest.java
@@ -1,0 +1,242 @@
+package com.enrollment.domain.enrollment.controller;
+
+import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.global.error.GlobalExceptionHandler;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(EnrollmentController.class)
+@Import(GlobalExceptionHandler.class)
+class EnrollmentControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @MockBean
+    EnrollmentService enrollmentService;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 1, 1, 0, 0);
+
+    private EnrollmentResponse sampleResponse(String status) {
+        return new EnrollmentResponse(100L, 10L, "Java 기초", status, NOW, null, null);
+    }
+
+    @Nested
+    class Enroll {
+
+        @Test
+        void 정상_신청_201() throws Exception {
+            given(enrollmentService.enroll(eq(2L), any())).willReturn(sampleResponse("PENDING"));
+
+            String body = """
+                    {"classId": 10}
+                    """;
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.enrollmentId").value(100))
+                    .andExpect(jsonPath("$.classId").value(10))
+                    .andExpect(jsonPath("$.status").value("PENDING"));
+        }
+
+        @Test
+        void classId_누락_시_400() throws Exception {
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+
+        @Test
+        void 강의_미존재_시_404() throws Exception {
+            given(enrollmentService.enroll(eq(2L), any()))
+                    .willThrow(new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"classId\": 999}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
+        }
+
+        @Test
+        void 사용자_미존재_시_404() throws Exception {
+            given(enrollmentService.enroll(eq(999L), any()))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 999L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"classId\": 10}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+        }
+
+        @Test
+        void 정원_초과_시_400() throws Exception {
+            given(enrollmentService.enroll(eq(2L), any()))
+                    .willThrow(new BusinessException(ErrorCode.CAPACITY_EXCEEDED));
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"classId\": 10}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("CAPACITY_EXCEEDED"));
+        }
+
+        @Test
+        void 이미_신청한_강의면_409() throws Exception {
+            given(enrollmentService.enroll(eq(2L), any()))
+                    .willThrow(new BusinessException(ErrorCode.ALREADY_ENROLLED));
+
+            mockMvc.perform(post("/enrollments")
+                            .header("X-User-Id", 2L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"classId\": 10}"))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("ALREADY_ENROLLED"));
+        }
+    }
+
+    @Nested
+    class Pay {
+
+        @Test
+        void 정상_결제_200() throws Exception {
+            given(enrollmentService.pay(2L, 100L)).willReturn(sampleResponse("CONFIRMED"));
+
+            mockMvc.perform(patch("/enrollments/100/pay")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("CONFIRMED"));
+        }
+
+        @Test
+        void 신청_미존재_시_404() throws Exception {
+            given(enrollmentService.pay(2L, 999L))
+                    .willThrow(new BusinessException(ErrorCode.ENROLLMENT_NOT_FOUND));
+
+            mockMvc.perform(patch("/enrollments/999/pay")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("ENROLLMENT_NOT_FOUND"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            given(enrollmentService.pay(999L, 100L))
+                    .willThrow(new BusinessException(ErrorCode.NOT_ENROLLMENT_OWNER));
+
+            mockMvc.perform(patch("/enrollments/100/pay")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_ENROLLMENT_OWNER"));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void 정상_취소_200() throws Exception {
+            given(enrollmentService.cancel(2L, 100L)).willReturn(sampleResponse("CANCELLED"));
+
+            mockMvc.perform(patch("/enrollments/100/cancel")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("CANCELLED"));
+        }
+
+        @Test
+        void 취소_기간_초과_시_400() throws Exception {
+            given(enrollmentService.cancel(2L, 100L))
+                    .willThrow(new BusinessException(ErrorCode.CANCEL_PERIOD_EXPIRED));
+
+            mockMvc.perform(patch("/enrollments/100/cancel")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("CANCEL_PERIOD_EXPIRED"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            given(enrollmentService.cancel(999L, 100L))
+                    .willThrow(new BusinessException(ErrorCode.NOT_ENROLLMENT_OWNER));
+
+            mockMvc.perform(patch("/enrollments/100/cancel")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_ENROLLMENT_OWNER"));
+        }
+
+        @Test
+        void 이미_취소된_신청이면_400() throws Exception {
+            given(enrollmentService.cancel(2L, 100L))
+                    .willThrow(new BusinessException(ErrorCode.ALREADY_CANCELLED));
+
+            mockMvc.perform(patch("/enrollments/100/cancel")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("ALREADY_CANCELLED"));
+        }
+    }
+
+    @Nested
+    class GetMyEnrollments {
+
+        @Test
+        void 내_신청_목록_200() throws Exception {
+            given(enrollmentService.getMyEnrollments(eq(2L), any()))
+                    .willReturn(new PageImpl<>(List.of(sampleResponse("PENDING")),
+                            PageRequest.of(0, 20), 1));
+
+            mockMvc.perform(get("/enrollments/me")
+                            .header("X-User-Id", 2L)
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].enrollmentId").value(100))
+                    .andExpect(jsonPath("$.totalElements").value(1));
+        }
+
+        @Test
+        void 사용자_미존재_시_404() throws Exception {
+            given(enrollmentService.getMyEnrollments(eq(999L), any()))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            mockMvc.perform(get("/enrollments/me")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+        }
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentStatusTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentStatusTest.java
@@ -1,0 +1,41 @@
+package com.enrollment.domain.enrollment.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnrollmentStatusTest {
+
+    @Test
+    void PENDING에서_CONFIRMED로_전이_가능() {
+        assertThat(EnrollmentStatus.PENDING.canTransitionTo(EnrollmentStatus.CONFIRMED)).isTrue();
+    }
+
+    @Test
+    void PENDING에서_CANCELLED로_전이_가능() {
+        assertThat(EnrollmentStatus.PENDING.canTransitionTo(EnrollmentStatus.CANCELLED)).isTrue();
+    }
+
+    @Test
+    void CONFIRMED에서_CANCELLED로_전이_가능() {
+        assertThat(EnrollmentStatus.CONFIRMED.canTransitionTo(EnrollmentStatus.CANCELLED)).isTrue();
+    }
+
+    @Test
+    void CONFIRMED에서_PENDING으로_전이_불가() {
+        assertThat(EnrollmentStatus.CONFIRMED.canTransitionTo(EnrollmentStatus.PENDING)).isFalse();
+    }
+
+    @Test
+    void CANCELLED에서_어디로도_전이_불가() {
+        assertThat(EnrollmentStatus.CANCELLED.canTransitionTo(EnrollmentStatus.PENDING)).isFalse();
+        assertThat(EnrollmentStatus.CANCELLED.canTransitionTo(EnrollmentStatus.CONFIRMED)).isFalse();
+    }
+
+    @Test
+    void 같은_상태로_전이_불가() {
+        assertThat(EnrollmentStatus.PENDING.canTransitionTo(EnrollmentStatus.PENDING)).isFalse();
+        assertThat(EnrollmentStatus.CONFIRMED.canTransitionTo(EnrollmentStatus.CONFIRMED)).isFalse();
+        assertThat(EnrollmentStatus.CANCELLED.canTransitionTo(EnrollmentStatus.CANCELLED)).isFalse();
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentTest.java
@@ -1,0 +1,206 @@
+package com.enrollment.domain.enrollment.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EnrollmentTest {
+
+    private User classmate;
+    private ClassEntity openClass;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+
+        classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+
+        openClass = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초")
+                .description("설명")
+                .price(10000)
+                .capacity(30)
+                .enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT)
+                .build();
+        setId(openClass, 10L);
+        openClass.publish();
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void create_시_PENDING_상태와_enrolledAt_설정() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+            assertThat(enrollment.getEnrolledAt()).isNotNull();
+            assertThat(enrollment.getConfirmedAt()).isNull();
+            assertThat(enrollment.getCancelledAt()).isNull();
+            assertThat(enrollment.getClassEntity()).isEqualTo(openClass);
+            assertThat(enrollment.getUser()).isEqualTo(classmate);
+        }
+    }
+
+    @Nested
+    class Confirm {
+
+        @Test
+        void PENDING에서_confirm_성공() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+            assertThat(enrollment.getConfirmedAt()).isNotNull();
+        }
+
+        @Test
+        void CONFIRMED에서_confirm_시_INVALID_STATE_TRANSITION() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            assertThatThrownBy(enrollment::confirm)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void CANCELLED에서_confirm_시_INVALID_STATE_TRANSITION() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.cancel();
+            assertThatThrownBy(enrollment::confirm)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void PENDING에서_cancel_성공() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.cancel();
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+            assertThat(enrollment.getCancelledAt()).isNotNull();
+        }
+
+        @Test
+        void CONFIRMED_7일_이내_cancel_성공() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            // confirmedAt을 6일 전으로 설정
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(6));
+
+            enrollment.cancel();
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+            assertThat(enrollment.getCancelledAt()).isNotNull();
+        }
+
+        @Test
+        void CONFIRMED_7일_초과_cancel_시_CANCEL_PERIOD_EXPIRED() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            // confirmedAt을 8일 전으로 설정
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(8));
+
+            assertThatThrownBy(enrollment::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CANCEL_PERIOD_EXPIRED));
+        }
+
+        @Test
+        void CONFIRMED_정확히_7일째_cancel_허용() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            // 7일 경계 바로 안쪽 → plusDays(7).isBefore(now) == false → 허용
+            // (테스트 실행 중 now()가 아주 미세하게 진행되므로 5초 버퍼 부여)
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(7).plusSeconds(5));
+
+            enrollment.cancel();
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        }
+
+        @Test
+        void CONFIRMED_7일_1초_후_cancel_실패() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.confirm();
+            // 7일 + 1초 경과 → CANCEL_PERIOD_EXPIRED
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(7).minusSeconds(1));
+
+            assertThatThrownBy(enrollment::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CANCEL_PERIOD_EXPIRED));
+        }
+
+        @Test
+        void CANCELLED에서_cancel_시_ALREADY_CANCELLED() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.cancel();
+            assertThatThrownBy(enrollment::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_CANCELLED));
+        }
+    }
+
+    @Nested
+    class ValidateOwner {
+
+        @Test
+        void 소유자_일치_시_예외_없음() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            enrollment.validateOwner(2L);
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_ENROLLMENT_OWNER_예외() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            assertThatThrownBy(() -> enrollment.validateOwner(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_ENROLLMENT_OWNER));
+        }
+    }
+
+    private Enrollment newEnrollment(ClassEntity classEntity, User user) {
+        return Enrollment.builder()
+                .classEntity(classEntity)
+                .user(user)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .build();
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+
+    private void setField(Object obj, String name, Object value) throws Exception {
+        Field field = obj.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/entity/EnrollmentTest.java
@@ -90,6 +90,88 @@ class EnrollmentTest {
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
         }
+
+        @Test
+        void 만료_이전_confirm_성공_후_expiresAt_null() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            setField(enrollment, "expiresAt", LocalDateTime.now().plusMinutes(10));
+
+            enrollment.confirm();
+
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+            assertThat(enrollment.getExpiresAt()).isNull();
+        }
+
+        @Test
+        void 만료_이후_confirm_시_HOLD_EXPIRED() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            setField(enrollment, "expiresAt", LocalDateTime.now().minusSeconds(1));
+
+            assertThatThrownBy(enrollment::confirm)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.HOLD_EXPIRED));
+        }
+    }
+
+    @Nested
+    class Expire {
+
+        @Test
+        void PENDING에서_expire_시_CANCELLED_및_cancelledAt_세팅() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+
+            enrollment.expire();
+
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+            assertThat(enrollment.getCancelledAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class IsExpired {
+
+        @Test
+        void expiresAt_null_이면_false() {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            assertThat(enrollment.isExpired()).isFalse();
+        }
+
+        @Test
+        void 정확히_30분_이전_expiresAt이면_false() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            // 30분 - 1초 (아직 유효)
+            setField(enrollment, "expiresAt", LocalDateTime.now().plusMinutes(29).plusSeconds(59));
+            assertThat(enrollment.isExpired()).isFalse();
+        }
+
+        @Test
+        void 과거_expiresAt이면_true() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            setField(enrollment, "expiresAt", LocalDateTime.now().minusSeconds(1));
+            assertThat(enrollment.isExpired()).isTrue();
+        }
+
+        @Test
+        void 미래_expiresAt이면_false() throws Exception {
+            Enrollment enrollment = newEnrollment(openClass, classmate);
+            setField(enrollment, "expiresAt", LocalDateTime.now().plusMinutes(30).plusSeconds(1));
+            assertThat(enrollment.isExpired()).isFalse();
+        }
+    }
+
+    @Nested
+    class DefaultExpiresAt {
+
+        @Test
+        void defaultExpiresAt은_현재시각_30분_후() {
+            LocalDateTime before = LocalDateTime.now().plusMinutes(30).minusSeconds(1);
+            LocalDateTime value = Enrollment.defaultExpiresAt();
+            LocalDateTime after = LocalDateTime.now().plusMinutes(30).plusSeconds(1);
+
+            assertThat(value).isAfter(before);
+            assertThat(value).isBefore(after);
+        }
     }
 
     @Nested

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/repository/EnrollmentRepositoryTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/repository/EnrollmentRepositoryTest.java
@@ -157,12 +157,79 @@ class EnrollmentRepositoryTest extends AbstractIntegrationTest {
         assertThat(saved.getId()).isNotNull();
     }
 
+    @Test
+    void findExpiredPendings_PENDING_만료된_것만_반환() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 만료된 PENDING
+        User expiredUser = userRepository.saveAndFlush(
+                User.builder().name("expiredStudent").role(UserRole.CLASSMATE).build());
+        Enrollment expired = enrollmentRepository.saveAndFlush(
+                pendingEnrollmentWithExpiresAt(openClass, expiredUser, now.minusMinutes(1)));
+
+        // 아직 만료 안 된 PENDING
+        User freshUser = userRepository.saveAndFlush(
+                User.builder().name("freshStudent").role(UserRole.CLASSMATE).build());
+        enrollmentRepository.saveAndFlush(
+                pendingEnrollmentWithExpiresAt(openClass, freshUser, now.plusMinutes(10)));
+
+        // CONFIRMED (만료 컬럼 무관)
+        User confirmedUser = userRepository.saveAndFlush(
+                User.builder().name("confirmedStudent").role(UserRole.CLASSMATE).build());
+        Enrollment confirmed = newEnrollment(openClass, confirmedUser);
+        confirmed.confirm();
+        enrollmentRepository.saveAndFlush(confirmed);
+
+        // CANCELLED
+        User cancelledUser = userRepository.saveAndFlush(
+                User.builder().name("cancelledStudent").role(UserRole.CLASSMATE).build());
+        Enrollment cancelled = newEnrollment(openClass, cancelledUser);
+        cancelled.cancel();
+        enrollmentRepository.saveAndFlush(cancelled);
+
+        em.clear();
+
+        List<Enrollment> result = enrollmentRepository.findExpiredPendings(
+                EnrollmentStatus.PENDING, now, PageRequest.of(0, 100));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(expired.getId());
+    }
+
+    @Test
+    void findExpiredPendings_LIMIT_적용() {
+        LocalDateTime now = LocalDateTime.now();
+        for (int i = 0; i < 5; i++) {
+            User u = userRepository.saveAndFlush(
+                    User.builder().name("student" + i).role(UserRole.CLASSMATE).build());
+            enrollmentRepository.saveAndFlush(
+                    pendingEnrollmentWithExpiresAt(openClass, u, now.minusMinutes(1)));
+        }
+        em.clear();
+
+        List<Enrollment> result = enrollmentRepository.findExpiredPendings(
+                EnrollmentStatus.PENDING, now, PageRequest.of(0, 2));
+
+        assertThat(result).hasSize(2);
+    }
+
     private Enrollment newEnrollment(ClassEntity classEntity, User user) {
         return Enrollment.builder()
                 .classEntity(classEntity)
                 .user(user)
                 .status(EnrollmentStatus.PENDING)
                 .enrolledAt(LocalDateTime.now())
+                .build();
+    }
+
+    private Enrollment pendingEnrollmentWithExpiresAt(
+            ClassEntity classEntity, User user, LocalDateTime expiresAt) {
+        return Enrollment.builder()
+                .classEntity(classEntity)
+                .user(user)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .expiresAt(expiresAt)
                 .build();
     }
 }

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/repository/EnrollmentRepositoryTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/repository/EnrollmentRepositoryTest.java
@@ -1,0 +1,168 @@
+package com.enrollment.domain.enrollment.repository;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.config.JpaAuditingConfig;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Import(JpaAuditingConfig.class)
+class EnrollmentRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    TestEntityManager em;
+    @Autowired
+    EnrollmentRepository enrollmentRepository;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+
+    private User creator;
+    private User classmate;
+    private ClassEntity openClass;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build()
+        );
+        classmate = userRepository.saveAndFlush(
+                User.builder().name("student").role(UserRole.CLASSMATE).build()
+        );
+        openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("Java 기초").description("설명")
+                        .price(10000).capacity(30).enrolledCount(0)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build()
+        );
+    }
+
+    @Test
+    void save_시_id_자동_생성_및_auditing() {
+        Enrollment saved = enrollmentRepository.saveAndFlush(
+                newEnrollment(openClass, classmate));
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+        assertThat(saved.getEnrolledAt()).isNotNull();
+    }
+
+    @Test
+    void findByIdForUpdate_JOIN_FETCH로_classEntity와_user_즉시_로딩() {
+        Long id = enrollmentRepository.saveAndFlush(
+                newEnrollment(openClass, classmate)).getId();
+        em.clear();
+
+        Optional<Enrollment> found = enrollmentRepository.findByIdForUpdate(id);
+        assertThat(found).isPresent();
+        // LazyInitializationException 없이 접근 가능해야 함
+        assertThat(found.get().getClassEntity().getTitle()).isEqualTo("Java 기초");
+        assertThat(found.get().getUser().getName()).isEqualTo("student");
+    }
+
+    @Test
+    void findByUserId_페이지네이션_성공() {
+        enrollmentRepository.saveAndFlush(newEnrollment(openClass, classmate));
+        em.clear();
+
+        Page<Enrollment> result = enrollmentRepository.findByUserId(
+                classmate.getId(), PageRequest.of(0, 10));
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        // EntityGraph must load classEntity eagerly
+        assertThat(result.getContent().get(0).getClassEntity().getTitle()).isEqualTo("Java 기초");
+    }
+
+    @Test
+    void findByClassEntityId_페이지네이션_성공() {
+        enrollmentRepository.saveAndFlush(newEnrollment(openClass, classmate));
+        em.clear();
+
+        Page<Enrollment> result = enrollmentRepository.findByClassEntityId(
+                openClass.getId(), PageRequest.of(0, 10));
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        // EntityGraph must load user eagerly
+        assertThat(result.getContent().get(0).getUser().getName()).isEqualTo("student");
+    }
+
+    @Test
+    void existsByClassIdAndUserIdAndStatusIn_중복_체크() {
+        enrollmentRepository.saveAndFlush(newEnrollment(openClass, classmate));
+        em.clear();
+
+        boolean exists = enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                openClass.getId(), classmate.getId(),
+                List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED));
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void existsByClassIdAndUserIdAndStatusIn_미존재시_false() {
+        boolean exists = enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                openClass.getId(), classmate.getId(),
+                List.of(EnrollmentStatus.PENDING, EnrollmentStatus.CONFIRMED));
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    void 부분_유니크_인덱스_활성_상태_중복_방지() {
+        enrollmentRepository.saveAndFlush(newEnrollment(openClass, classmate));
+        em.clear();
+
+        Enrollment duplicate = newEnrollment(openClass, classmate);
+        assertThatThrownBy(() -> enrollmentRepository.saveAndFlush(duplicate))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 부분_유니크_인덱스_CANCELLED_후_재신청_허용() {
+        Enrollment first = enrollmentRepository.saveAndFlush(
+                newEnrollment(openClass, classmate));
+        first.cancel();
+        enrollmentRepository.saveAndFlush(first);
+        em.clear();
+
+        Enrollment secondAttempt = newEnrollment(openClass, classmate);
+        Enrollment saved = enrollmentRepository.saveAndFlush(secondAttempt);
+        assertThat(saved.getId()).isNotNull();
+    }
+
+    private Enrollment newEnrollment(ClassEntity classEntity, User user) {
+        return Enrollment.builder()
+                .classEntity(classEntity)
+                .user(user)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/scheduler/EnrollmentExpirationSchedulerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/scheduler/EnrollmentExpirationSchedulerTest.java
@@ -1,0 +1,184 @@
+package com.enrollment.domain.enrollment.scheduler;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.domain.waitlist.repository.WaitlistRepository;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class EnrollmentExpirationSchedulerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    EnrollmentExpirationScheduler scheduler;
+    @Autowired
+    EnrollmentRepository enrollmentRepository;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    WaitlistRepository waitlistRepository;
+    @Autowired
+    TransactionTemplate transactionTemplate;
+
+    private User creator;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build());
+    }
+
+    @Test
+    void 만료된_PENDING_실행_시_CANCELLED_및_enrolledCount_감소() {
+        User classmate = userRepository.saveAndFlush(
+                User.builder().name("student").role(UserRole.CLASSMATE).build());
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("Java 기초").description("설명")
+                        .price(10000).capacity(10).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+
+        // 만료된 PENDING 생성
+        Enrollment saved = transactionTemplate.execute(s ->
+                enrollmentRepository.saveAndFlush(
+                        Enrollment.builder()
+                                .classEntity(classRepository.findById(openClass.getId()).orElseThrow())
+                                .user(userRepository.findById(classmate.getId()).orElseThrow())
+                                .status(EnrollmentStatus.PENDING)
+                                .enrolledAt(LocalDateTime.now().minusMinutes(31))
+                                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                                .build()));
+
+        // 만료 스캔 수동 실행
+        scheduler.expirePendings();
+
+        Enrollment result = enrollmentRepository.findById(saved.getId()).orElseThrow();
+        assertThat(result.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(result.getCancelledAt()).isNotNull();
+
+        ClassEntity updatedClass = classRepository.findById(openClass.getId()).orElseThrow();
+        assertThat(updatedClass.getEnrolledCount()).isEqualTo(0);
+    }
+
+    @Test
+    void 만료_이후_대기자_있으면_체인_승격() {
+        User pendingUser = userRepository.saveAndFlush(
+                User.builder().name("pending").role(UserRole.CLASSMATE).build());
+        User waitingUser = userRepository.saveAndFlush(
+                User.builder().name("waiting").role(UserRole.CLASSMATE).build());
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("인기_강의").description("정원 1")
+                        .price(10000).capacity(1).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+
+        // 만료된 PENDING + WAITING 1명 사전 세팅
+        Enrollment expired = transactionTemplate.execute(s ->
+                enrollmentRepository.saveAndFlush(
+                        Enrollment.builder()
+                                .classEntity(classRepository.findById(openClass.getId()).orElseThrow())
+                                .user(userRepository.findById(pendingUser.getId()).orElseThrow())
+                                .status(EnrollmentStatus.PENDING)
+                                .enrolledAt(LocalDateTime.now().minusMinutes(31))
+                                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                                .build()));
+
+        transactionTemplate.executeWithoutResult(s ->
+                waitlistRepository.saveAndFlush(
+                        Waitlist.builder()
+                                .classEntity(classRepository.findById(openClass.getId()).orElseThrow())
+                                .user(userRepository.findById(waitingUser.getId()).orElseThrow())
+                                .status(WaitlistStatus.WAITING)
+                                .build()));
+
+        // 만료 스캔 실행
+        scheduler.expirePendings();
+
+        // 기존 PENDING → CANCELLED
+        Enrollment expiredResult = enrollmentRepository.findById(expired.getId()).orElseThrow();
+        assertThat(expiredResult.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+
+        // 대기자 승격 확인
+        List<Waitlist> waitlists = waitlistRepository.findAll().stream()
+                .filter(w -> w.getClassEntity().getId().equals(openClass.getId()))
+                .toList();
+        assertThat(waitlists).hasSize(1);
+        assertThat(waitlists.get(0).getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+
+        // 새 PENDING + expiresAt 세팅 확인
+        List<Enrollment> pendings = enrollmentRepository.findAll().stream()
+                .filter(e -> e.getClassEntity().getId().equals(openClass.getId())
+                        && e.getStatus() == EnrollmentStatus.PENDING)
+                .toList();
+        assertThat(pendings).hasSize(1);
+        assertThat(pendings.get(0).getUser().getId()).isEqualTo(waitingUser.getId());
+        assertThat(pendings.get(0).getExpiresAt()).isNotNull();
+        assertThat(pendings.get(0).getExpiresAt()).isAfter(LocalDateTime.now().plusMinutes(29));
+
+        // 좌석 유지 (만료 -1, 승격 +1 = net 0)
+        ClassEntity updatedClass = classRepository.findById(openClass.getId()).orElseThrow();
+        assertThat(updatedClass.getEnrolledCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 대기자_없으면_좌석만_해제() {
+        User classmate = userRepository.saveAndFlush(
+                User.builder().name("only").role(UserRole.CLASSMATE).build());
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("여유_강의").description("정원 10")
+                        .price(10000).capacity(10).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+
+        transactionTemplate.executeWithoutResult(s ->
+                enrollmentRepository.saveAndFlush(
+                        Enrollment.builder()
+                                .classEntity(classRepository.findById(openClass.getId()).orElseThrow())
+                                .user(userRepository.findById(classmate.getId()).orElseThrow())
+                                .status(EnrollmentStatus.PENDING)
+                                .enrolledAt(LocalDateTime.now().minusMinutes(31))
+                                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                                .build()));
+
+        scheduler.expirePendings();
+
+        ClassEntity updatedClass = classRepository.findById(openClass.getId()).orElseThrow();
+        assertThat(updatedClass.getEnrolledCount()).isEqualTo(0);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
@@ -205,7 +205,7 @@ class EnrollmentServiceTest {
         void 정상_결제() throws Exception {
             ClassEntity openClass = openClass(30, 1);
             Enrollment enrollment = pendingEnrollment(openClass);
-            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
 
             ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
             given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
@@ -223,7 +223,7 @@ class EnrollmentServiceTest {
 
         @Test
         void 신청_미존재_시_ENROLLMENT_NOT_FOUND() {
-            given(enrollmentRepository.findWithClassAndUserById(999L)).willReturn(Optional.empty());
+            given(enrollmentRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> enrollmentService.pay(2L, 999L))
                     .isInstanceOf(BusinessException.class)
@@ -235,7 +235,7 @@ class EnrollmentServiceTest {
         void 소유자_불일치_시_NOT_ENROLLMENT_OWNER() throws Exception {
             ClassEntity openClass = openClass(30, 1);
             Enrollment enrollment = pendingEnrollment(openClass);
-            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
 
             assertThatThrownBy(() -> enrollmentService.pay(999L, 100L))
                     .isInstanceOf(BusinessException.class)
@@ -248,12 +248,25 @@ class EnrollmentServiceTest {
             ClassEntity openClass = openClass(30, 1);
             Enrollment enrollment = pendingEnrollment(openClass);
             enrollment.confirm();
-            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
 
             assertThatThrownBy(() -> enrollmentService.pay(2L, 100L))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void 만료된_PENDING_결제_시_HOLD_EXPIRED() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            setField(enrollment, "expiresAt", LocalDateTime.now().minusMinutes(1));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+
+            assertThatThrownBy(() -> enrollmentService.pay(2L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.HOLD_EXPIRED));
         }
     }
 

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
@@ -1,0 +1,428 @@
+package com.enrollment.domain.enrollment.service;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.dto.EnrollmentCreateRequest;
+import com.enrollment.domain.enrollment.dto.EnrollmentResponse;
+import com.enrollment.domain.enrollment.dto.EnrollmentWithUserResponse;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.payment.entity.Payment;
+import com.enrollment.domain.payment.entity.PaymentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.payment.repository.PaymentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentServiceTest {
+
+    @Mock
+    EnrollmentRepository enrollmentRepository;
+    @Mock
+    PaymentRepository paymentRepository;
+    @Mock
+    ClassRepository classRepository;
+    @Mock
+    UserRepository userRepository;
+    @InjectMocks
+    EnrollmentService enrollmentService;
+
+    private User creator;
+    private User classmate;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+        classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+    }
+
+    private ClassEntity openClass(int capacity, int enrolled) throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(capacity).enrolledCount(enrolled)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        entity.publish();
+        return entity;
+    }
+
+    private ClassEntity draftClass() throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(30).enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        return entity;
+    }
+
+    private Enrollment pendingEnrollment(ClassEntity classEntity) throws Exception {
+        Enrollment enrollment = Enrollment.builder()
+                .classEntity(classEntity)
+                .user(classmate)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .build();
+        setId(enrollment, 100L);
+        return enrollment;
+    }
+
+    @Nested
+    class Enroll {
+
+        @Test
+        void 정상_신청() throws Exception {
+            ClassEntity openClass = openClass(30, 0);
+            EnrollmentCreateRequest request = new EnrollmentCreateRequest(10L);
+
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+            given(enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                    eq(10L), eq(2L), anyCollection())).willReturn(false);
+            given(enrollmentRepository.save(any(Enrollment.class))).willAnswer(inv -> {
+                Enrollment e = inv.getArgument(0);
+                try { setId(e, 100L); } catch (Exception ignored) {}
+                return e;
+            });
+
+            EnrollmentResponse response = enrollmentService.enroll(2L, request);
+
+            assertThat(response.enrollmentId()).isEqualTo(100L);
+            assertThat(response.classId()).isEqualTo(10L);
+            assertThat(response.status()).isEqualTo("PENDING");
+            assertThat(openClass.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 사용자_미존재_시_USER_NOT_FOUND() {
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.enroll(999L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+
+        @Test
+        void 강의_미존재_시_CLASS_NOT_FOUND() {
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.enroll(2L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CLASS_NOT_FOUND));
+        }
+
+        @Test
+        void 강의가_OPEN이_아니면_INVALID_STATE_TRANSITION() throws Exception {
+            ClassEntity draft = draftClass();
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(draft));
+
+            assertThatThrownBy(() -> enrollmentService.enroll(2L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void 이미_신청한_강의면_ALREADY_ENROLLED() throws Exception {
+            ClassEntity openClass = openClass(30, 0);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+            given(enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                    eq(10L), eq(2L), anyCollection())).willReturn(true);
+
+            assertThatThrownBy(() -> enrollmentService.enroll(2L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_ENROLLED));
+        }
+
+        @Test
+        void 정원_초과_시_CAPACITY_EXCEEDED() throws Exception {
+            ClassEntity fullClass = openClass(2, 2);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(fullClass));
+            given(enrollmentRepository.existsByClassIdAndUserIdAndStatusIn(
+                    eq(10L), eq(2L), anyCollection())).willReturn(false);
+
+            assertThatThrownBy(() -> enrollmentService.enroll(2L, new EnrollmentCreateRequest(10L)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CAPACITY_EXCEEDED));
+            verify(enrollmentRepository, never()).save(any(Enrollment.class));
+        }
+    }
+
+    @Nested
+    class Pay {
+
+        @Test
+        void 정상_결제() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+
+            ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+            given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+            EnrollmentResponse response = enrollmentService.pay(2L, 100L);
+
+            assertThat(response.status()).isEqualTo("CONFIRMED");
+            assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+
+            verify(paymentRepository).save(paymentCaptor.capture());
+            Payment saved = paymentCaptor.getValue();
+            assertThat(saved.getStatus()).isEqualTo(PaymentStatus.PAID);
+            assertThat(saved.getAmount()).isEqualTo(10000);
+        }
+
+        @Test
+        void 신청_미존재_시_ENROLLMENT_NOT_FOUND() {
+            given(enrollmentRepository.findWithClassAndUserById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.pay(2L, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ENROLLMENT_NOT_FOUND));
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_ENROLLMENT_OWNER() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+
+            assertThatThrownBy(() -> enrollmentService.pay(999L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_ENROLLMENT_OWNER));
+        }
+
+        @Test
+        void CONFIRMED_상태에서_재결제_시_INVALID_STATE_TRANSITION() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            enrollment.confirm();
+            given(enrollmentRepository.findWithClassAndUserById(100L)).willReturn(Optional.of(enrollment));
+
+            assertThatThrownBy(() -> enrollmentService.pay(2L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void PENDING_취소_환불없음() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+
+            EnrollmentResponse response = enrollmentService.cancel(2L, 100L);
+
+            assertThat(response.status()).isEqualTo("CANCELLED");
+            assertThat(openClass.getEnrolledCount()).isEqualTo(0);
+            verify(paymentRepository, never()).save(any(Payment.class));
+        }
+
+        @Test
+        void CONFIRMED_7일_이내_취소_환불_발생() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            enrollment.confirm();
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(3));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+            given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+            EnrollmentResponse response = enrollmentService.cancel(2L, 100L);
+
+            assertThat(response.status()).isEqualTo("CANCELLED");
+            assertThat(openClass.getEnrolledCount()).isEqualTo(0);
+
+            ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+            verify(paymentRepository).save(captor.capture());
+            assertThat(captor.getValue().getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        }
+
+        @Test
+        void CONFIRMED_7일_초과_시_CANCEL_PERIOD_EXPIRED() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            enrollment.confirm();
+            setField(enrollment, "confirmedAt", LocalDateTime.now().minusDays(8));
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+
+            assertThatThrownBy(() -> enrollmentService.cancel(2L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CANCEL_PERIOD_EXPIRED));
+            verify(paymentRepository, never()).save(any(Payment.class));
+            assertThat(openClass.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_ENROLLMENT_OWNER() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+
+            assertThatThrownBy(() -> enrollmentService.cancel(999L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_ENROLLMENT_OWNER));
+        }
+
+        @Test
+        void 신청_미존재_시_ENROLLMENT_NOT_FOUND() {
+            given(enrollmentRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.cancel(2L, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ENROLLMENT_NOT_FOUND));
+        }
+
+        @Test
+        void 이미_취소된_신청이면_ALREADY_CANCELLED() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            enrollment.cancel();
+            given(enrollmentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(enrollment));
+            given(classRepository.findByIdForUpdate(10L)).willReturn(Optional.of(openClass));
+
+            assertThatThrownBy(() -> enrollmentService.cancel(2L, 100L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_CANCELLED));
+        }
+    }
+
+    @Nested
+    class GetMyEnrollments {
+
+        @Test
+        void 내_신청_목록_조회_성공() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            Page<Enrollment> page = new PageImpl<>(List.of(enrollment));
+            Pageable pageable = PageRequest.of(0, 20);
+
+            given(userRepository.existsById(2L)).willReturn(true);
+            given(enrollmentRepository.findByUserId(2L, pageable)).willReturn(page);
+
+            Page<EnrollmentResponse> result = enrollmentService.getMyEnrollments(2L, pageable);
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).classId()).isEqualTo(10L);
+        }
+
+        @Test
+        void 사용자_미존재_시_USER_NOT_FOUND() {
+            given(userRepository.existsById(999L)).willReturn(false);
+
+            assertThatThrownBy(() -> enrollmentService.getMyEnrollments(999L, PageRequest.of(0, 20)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    class GetClassEnrollments {
+
+        @Test
+        void 강사_본인_강의_수강생_목록_조회_성공() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            Enrollment enrollment = pendingEnrollment(openClass);
+            Page<Enrollment> page = new PageImpl<>(List.of(enrollment));
+            Pageable pageable = PageRequest.of(0, 20);
+
+            given(classRepository.findWithCreatorById(10L)).willReturn(Optional.of(openClass));
+            given(enrollmentRepository.findByClassEntityId(10L, pageable)).willReturn(page);
+
+            Page<EnrollmentWithUserResponse> result = enrollmentService.getClassEnrollments(1L, 10L, pageable);
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).userName()).isEqualTo("student");
+        }
+
+        @Test
+        void 강의_미존재_시_CLASS_NOT_FOUND() {
+            given(classRepository.findWithCreatorById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> enrollmentService.getClassEnrollments(1L, 999L, PageRequest.of(0, 20)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CLASS_NOT_FOUND));
+        }
+
+        @Test
+        void 강사_소유자_아니면_NOT_COURSE_OWNER() throws Exception {
+            ClassEntity openClass = openClass(30, 1);
+            given(classRepository.findWithCreatorById(10L)).willReturn(Optional.of(openClass));
+
+            assertThatThrownBy(() -> enrollmentService.getClassEnrollments(999L, 10L, PageRequest.of(0, 20)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_COURSE_OWNER));
+        }
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+
+    private void setField(Object obj, String name, Object value) throws Exception {
+        Field field = obj.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(obj, value);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/enrollment/service/EnrollmentServiceTest.java
@@ -15,6 +15,7 @@ import com.enrollment.domain.payment.repository.PaymentRepository;
 import com.enrollment.domain.user.entity.User;
 import com.enrollment.domain.user.entity.UserRole;
 import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.service.WaitlistService;
 import com.enrollment.global.error.exception.BusinessException;
 import com.enrollment.global.error.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +57,8 @@ class EnrollmentServiceTest {
     ClassRepository classRepository;
     @Mock
     UserRepository userRepository;
+    @Mock
+    WaitlistService waitlistService;
     @InjectMocks
     EnrollmentService enrollmentService;
 

--- a/enrollment-api/src/test/java/com/enrollment/domain/payment/entity/PaymentTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/payment/entity/PaymentTest.java
@@ -1,0 +1,75 @@
+package com.enrollment.domain.payment.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PaymentTest {
+
+    private Enrollment enrollment;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+
+        User classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+
+        ClassEntity openClass = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초")
+                .description("설명")
+                .price(10000)
+                .capacity(30)
+                .enrolledCount(0)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT)
+                .build();
+        setId(openClass, 10L);
+        openClass.publish();
+
+        enrollment = Enrollment.builder()
+                .classEntity(openClass)
+                .user(classmate)
+                .status(EnrollmentStatus.PENDING)
+                .enrolledAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Test
+    void paid_팩토리_메서드_PAID_상태_생성() {
+        Payment payment = Payment.paid(enrollment, 10000);
+        assertThat(payment.getEnrollment()).isEqualTo(enrollment);
+        assertThat(payment.getAmount()).isEqualTo(10000);
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+        assertThat(payment.getPaidAt()).isNotNull();
+    }
+
+    @Test
+    void refunded_팩토리_메서드_REFUNDED_상태_생성() {
+        Payment payment = Payment.refunded(enrollment, 10000);
+        assertThat(payment.getEnrollment()).isEqualTo(enrollment);
+        assertThat(payment.getAmount()).isEqualTo(10000);
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        assertThat(payment.getPaidAt()).isNotNull();
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/user/UserRepositoryTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/user/UserRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.enrollment.domain.user;
+
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.global.config.JpaAuditingConfig;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Import(JpaAuditingConfig.class)
+class UserRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    TestEntityManager em;
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    void save_시_id_자동_생성() {
+        User saved = userRepository.saveAndFlush(
+            User.builder().name("kim").role(UserRole.CLASSMATE).build()
+        );
+        assertThat(saved.getId()).isNotNull();
+    }
+
+    @Test
+    void findById_왕복() {
+        Long id = userRepository.saveAndFlush(
+            User.builder().name("kim").role(UserRole.CLASSMATE).build()
+        ).getId();
+        em.clear();
+        User found = userRepository.findById(id).orElseThrow();
+        assertThat(found.getName()).isEqualTo("kim");
+        assertThat(found.getRole()).isEqualTo(UserRole.CLASSMATE);
+    }
+
+    @Test
+    void Auditing_자동_주입() {
+        User saved = userRepository.saveAndFlush(
+            User.builder().name("kim").role(UserRole.CREATOR).build()
+        );
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void name_null_시_제약_위반() {
+        User invalid = User.builder().role(UserRole.CLASSMATE).build();
+        assertThatThrownBy(() -> userRepository.saveAndFlush(invalid))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/WaitlistConcurrencyTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/WaitlistConcurrencyTest.java
@@ -1,0 +1,264 @@
+package com.enrollment.domain.waitlist;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.domain.waitlist.repository.WaitlistRepository;
+import com.enrollment.domain.waitlist.service.WaitlistService;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class WaitlistConcurrencyTest extends AbstractIntegrationTest {
+
+    @Autowired
+    EnrollmentService enrollmentService;
+    @Autowired
+    WaitlistService waitlistService;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    EnrollmentRepository enrollmentRepository;
+    @Autowired
+    WaitlistRepository waitlistRepository;
+    @Autowired
+    TransactionTemplate transactionTemplate;
+
+    private User creator;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build());
+    }
+
+    @Test
+    void 정원_1_CONFIRMED_1명_대기_3명_상태에서_1건_취소_시_정확히_1명_승격() throws Exception {
+        // 정원 1, CONFIRMED 1명 + WAITING 3명
+        User confirmedUser = userRepository.saveAndFlush(
+                User.builder().name("confirmed").role(UserRole.CLASSMATE).build());
+        List<Long> waitingUserIds = IntStream.range(0, 3)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("waiting" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("마감_강의").description("정원 1")
+                        .price(10000).capacity(1).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+        Long classId = openClass.getId();
+
+        // CONFIRMED 수강 신청 선삽입
+        Enrollment confirmed = transactionTemplate.execute(status ->
+                enrollmentRepository.saveAndFlush(
+                        Enrollment.builder()
+                                .classEntity(classRepository.findById(classId).orElseThrow())
+                                .user(userRepository.findById(confirmedUser.getId()).orElseThrow())
+                                .status(EnrollmentStatus.CONFIRMED)
+                                .enrolledAt(LocalDateTime.now())
+                                .confirmedAt(LocalDateTime.now())
+                                .build()));
+
+        // WAITING 3명 선삽입
+        for (Long waitingId : waitingUserIds) {
+            transactionTemplate.executeWithoutResult(s ->
+                    waitlistRepository.saveAndFlush(
+                            Waitlist.builder()
+                                    .classEntity(classRepository.findById(classId).orElseThrow())
+                                    .user(userRepository.findById(waitingId).orElseThrow())
+                                    .status(WaitlistStatus.WAITING)
+                                    .build()));
+        }
+
+        // CONFIRMED 취소 실행
+        enrollmentService.cancel(confirmedUser.getId(), confirmed.getId());
+
+        // 검증
+        ClassEntity finalClass = classRepository.findById(classId).orElseThrow();
+        assertThat(finalClass.getEnrolledCount()).isEqualTo(1);
+
+        long promotedCount = waitlistRepository.findAll().stream()
+                .filter(w -> w.getClassEntity().getId().equals(classId)
+                        && w.getStatus() == WaitlistStatus.PROMOTED)
+                .count();
+        assertThat(promotedCount).isEqualTo(1);
+
+        long pendingEnrollments = enrollmentRepository.findAll().stream()
+                .filter(e -> e.getClassEntity().getId().equals(classId)
+                        && e.getStatus() == EnrollmentStatus.PENDING)
+                .count();
+        assertThat(pendingEnrollments).isEqualTo(1);
+    }
+
+    @Test
+    void 정원_10_CONFIRMED_10명_대기_10명_상태에서_2건_동시_취소_시_2명_승격_net_zero() throws Exception {
+        // 정원 10, CONFIRMED 10 + WAITING 10
+        List<Long> confirmedUserIds = IntStream.range(0, 10)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("confirmed" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+        List<Long> waitingUserIds = IntStream.range(0, 10)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("waiting" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("인기_강의").description("정원 10")
+                        .price(10000).capacity(10).enrolledCount(10)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+        Long classId = openClass.getId();
+
+        // CONFIRMED 10명 선삽입
+        List<Long> confirmedEnrollmentIds = confirmedUserIds.stream()
+                .map(uid -> transactionTemplate.execute(s ->
+                        enrollmentRepository.saveAndFlush(
+                                Enrollment.builder()
+                                        .classEntity(classRepository.findById(classId).orElseThrow())
+                                        .user(userRepository.findById(uid).orElseThrow())
+                                        .status(EnrollmentStatus.CONFIRMED)
+                                        .enrolledAt(LocalDateTime.now())
+                                        .confirmedAt(LocalDateTime.now())
+                                        .build()).getId()))
+                .toList();
+
+        // WAITING 10명 선삽입
+        for (Long waitingId : waitingUserIds) {
+            transactionTemplate.executeWithoutResult(s ->
+                    waitlistRepository.saveAndFlush(
+                            Waitlist.builder()
+                                    .classEntity(classRepository.findById(classId).orElseThrow())
+                                    .user(userRepository.findById(waitingId).orElseThrow())
+                                    .status(WaitlistStatus.WAITING)
+                                    .build()));
+        }
+
+        // 동시 취소 2건
+        List<Long> cancelTargets = confirmedEnrollmentIds.subList(0, 2);
+        List<Long> cancelUserIds = confirmedUserIds.subList(0, 2);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(2);
+        AtomicInteger successCount = new AtomicInteger();
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        for (int i = 0; i < 2; i++) {
+            final int idx = i;
+            pool.submit(() -> {
+                try {
+                    startLatch.await();
+                    enrollmentService.cancel(cancelUserIds.get(idx), cancelTargets.get(idx));
+                    successCount.incrementAndGet();
+                } catch (Exception ignored) {
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        boolean finished = doneLatch.await(30, TimeUnit.SECONDS);
+        pool.shutdown();
+
+        assertThat(finished).isTrue();
+        assertThat(successCount.get()).isEqualTo(2);
+
+        // net-zero: enrolledCount 유지 (decrement 2 + increment 2 for promotion)
+        ClassEntity finalClass = classRepository.findById(classId).orElseThrow();
+        assertThat(finalClass.getEnrolledCount()).isEqualTo(10);
+
+        long promotedCount = waitlistRepository.findAll().stream()
+                .filter(w -> w.getClassEntity().getId().equals(classId)
+                        && w.getStatus() == WaitlistStatus.PROMOTED)
+                .count();
+        assertThat(promotedCount).isEqualTo(2);
+    }
+
+    @Test
+    void 다른_유저_5명_동시_register_시_모두_성공() throws Exception {
+        // 정원 찬 강의 준비
+        ClassEntity openClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("인기_강의").description("정원 1")
+                        .price(10000).capacity(1).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build());
+        Long classId = openClass.getId();
+
+        List<Long> classmateIds = IntStream.range(0, 5)
+                .mapToObj(i -> userRepository.saveAndFlush(
+                        User.builder().name("student" + i).role(UserRole.CLASSMATE).build()).getId())
+                .toList();
+
+        int threadCount = classmateIds.size();
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+
+        for (Long classmateId : classmateIds) {
+            pool.submit(() -> {
+                try {
+                    startLatch.await();
+                    waitlistService.register(classmateId, classId);
+                    successCount.incrementAndGet();
+                } catch (Exception ignored) {
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        boolean finished = doneLatch.await(30, TimeUnit.SECONDS);
+        pool.shutdown();
+
+        assertThat(finished).isTrue();
+        assertThat(successCount.get()).isEqualTo(threadCount);
+
+        long waitingCount = waitlistRepository.findAll().stream()
+                .filter(w -> w.getClassEntity().getId().equals(classId)
+                        && w.getStatus() == WaitlistStatus.WAITING)
+                .count();
+        assertThat(waitingCount).isEqualTo(5);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/controller/WaitlistControllerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/controller/WaitlistControllerTest.java
@@ -1,0 +1,157 @@
+package com.enrollment.domain.waitlist.controller;
+
+import com.enrollment.domain.waitlist.dto.WaitlistResponse;
+import com.enrollment.domain.waitlist.service.WaitlistService;
+import com.enrollment.global.error.GlobalExceptionHandler;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(WaitlistController.class)
+@Import(GlobalExceptionHandler.class)
+class WaitlistControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @MockBean
+    WaitlistService waitlistService;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2025, 1, 1, 0, 0);
+
+    private WaitlistResponse sampleResponse() {
+        return new WaitlistResponse(500L, 10L, "Java 기초", "WAITING", NOW);
+    }
+
+    @Nested
+    class Register {
+
+        @Test
+        void 정상_등록_201() throws Exception {
+            given(waitlistService.register(2L, 10L)).willReturn(sampleResponse());
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.waitlistId").value(500))
+                    .andExpect(jsonPath("$.classId").value(10))
+                    .andExpect(jsonPath("$.classTitle").value("Java 기초"))
+                    .andExpect(jsonPath("$.status").value("WAITING"));
+        }
+
+        @Test
+        void WAITLIST_NOT_ALLOWED_시_400() throws Exception {
+            given(waitlistService.register(2L, 10L))
+                    .willThrow(new BusinessException(ErrorCode.WAITLIST_NOT_ALLOWED));
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("WAITLIST_NOT_ALLOWED"));
+        }
+
+        @Test
+        void 강의_미존재_시_404() throws Exception {
+            given(waitlistService.register(2L, 999L))
+                    .willThrow(new BusinessException(ErrorCode.CLASS_NOT_FOUND));
+
+            mockMvc.perform(post("/classes/999/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
+        }
+
+        @Test
+        void 사용자_미존재_시_404() throws Exception {
+            given(waitlistService.register(999L, 10L))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+        }
+
+        @Test
+        void 이미_신청한_강의면_409() throws Exception {
+            given(waitlistService.register(2L, 10L))
+                    .willThrow(new BusinessException(ErrorCode.ALREADY_ENROLLED));
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("ALREADY_ENROLLED"));
+        }
+
+        @Test
+        void 이미_대기중이면_409() throws Exception {
+            given(waitlistService.register(2L, 10L))
+                    .willThrow(new BusinessException(ErrorCode.ALREADY_IN_WAITLIST));
+
+            mockMvc.perform(post("/classes/10/waitlist")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("ALREADY_IN_WAITLIST"));
+        }
+
+        @Test
+        void X_User_Id_누락_시_400() throws Exception {
+            mockMvc.perform(post("/classes/10/waitlist"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void 정상_철회_204() throws Exception {
+            doNothing().when(waitlistService).cancelWaitlist(2L, 10L);
+
+            mockMvc.perform(delete("/classes/10/waitlist/me")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 대기열_미존재_시_404() throws Exception {
+            willThrow(new BusinessException(ErrorCode.WAITLIST_NOT_FOUND))
+                    .given(waitlistService).cancelWaitlist(2L, 10L);
+
+            mockMvc.perform(delete("/classes/10/waitlist/me")
+                            .header("X-User-Id", 2L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("WAITLIST_NOT_FOUND"));
+        }
+
+        @Test
+        void 소유자_불일치_시_403() throws Exception {
+            willThrow(new BusinessException(ErrorCode.NOT_WAITLIST_OWNER))
+                    .given(waitlistService).cancelWaitlist(999L, 10L);
+
+            mockMvc.perform(delete("/classes/10/waitlist/me")
+                            .header("X-User-Id", 999L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOT_WAITLIST_OWNER"));
+        }
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/entity/WaitlistStatusTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/entity/WaitlistStatusTest.java
@@ -1,0 +1,37 @@
+package com.enrollment.domain.waitlist.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WaitlistStatusTest {
+
+    @Test
+    void WAITING에서_PROMOTED로_전이_가능() {
+        assertThat(WaitlistStatus.WAITING.canTransitionTo(WaitlistStatus.PROMOTED)).isTrue();
+    }
+
+    @Test
+    void WAITING에서_CANCELLED로_전이_가능() {
+        assertThat(WaitlistStatus.WAITING.canTransitionTo(WaitlistStatus.CANCELLED)).isTrue();
+    }
+
+    @Test
+    void PROMOTED에서_어디로도_전이_불가() {
+        assertThat(WaitlistStatus.PROMOTED.canTransitionTo(WaitlistStatus.WAITING)).isFalse();
+        assertThat(WaitlistStatus.PROMOTED.canTransitionTo(WaitlistStatus.CANCELLED)).isFalse();
+    }
+
+    @Test
+    void CANCELLED에서_어디로도_전이_불가() {
+        assertThat(WaitlistStatus.CANCELLED.canTransitionTo(WaitlistStatus.WAITING)).isFalse();
+        assertThat(WaitlistStatus.CANCELLED.canTransitionTo(WaitlistStatus.PROMOTED)).isFalse();
+    }
+
+    @Test
+    void 같은_상태로_전이_불가() {
+        assertThat(WaitlistStatus.WAITING.canTransitionTo(WaitlistStatus.WAITING)).isFalse();
+        assertThat(WaitlistStatus.PROMOTED.canTransitionTo(WaitlistStatus.PROMOTED)).isFalse();
+        assertThat(WaitlistStatus.CANCELLED.canTransitionTo(WaitlistStatus.CANCELLED)).isFalse();
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/entity/WaitlistTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/entity/WaitlistTest.java
@@ -1,0 +1,171 @@
+package com.enrollment.domain.waitlist.entity;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WaitlistTest {
+
+    private User classmate;
+    private ClassEntity openClass;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+
+        classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+
+        openClass = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초")
+                .description("설명")
+                .price(10000)
+                .capacity(1)
+                .enrolledCount(1)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT)
+                .build();
+        setId(openClass, 10L);
+        openClass.publish();
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void create_시_WAITING_상태와_null_필드() {
+            Waitlist waitlist = newWaitlist();
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.WAITING);
+            assertThat(waitlist.getPromotedAt()).isNull();
+            assertThat(waitlist.getPromotedEnrollmentId()).isNull();
+            assertThat(waitlist.getCancelledAt()).isNull();
+            assertThat(waitlist.getClassEntity()).isEqualTo(openClass);
+            assertThat(waitlist.getUser()).isEqualTo(classmate);
+        }
+    }
+
+    @Nested
+    class Promote {
+
+        @Test
+        void WAITING에서_promote_성공() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.promote(555L);
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+            assertThat(waitlist.getPromotedEnrollmentId()).isEqualTo(555L);
+            assertThat(waitlist.getPromotedAt()).isNotNull();
+        }
+
+        @Test
+        void PROMOTED에서_promote_시_INVALID_STATE_TRANSITION() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.promote(555L);
+            assertThatThrownBy(() -> waitlist.promote(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void CANCELLED에서_promote_시_INVALID_STATE_TRANSITION() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.cancel();
+            assertThatThrownBy(() -> waitlist.promote(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+    }
+
+    @Nested
+    class Cancel {
+
+        @Test
+        void WAITING에서_cancel_성공() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.cancel();
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(waitlist.getCancelledAt()).isNotNull();
+        }
+
+        @Test
+        void PROMOTED에서_cancel_시_INVALID_STATE_TRANSITION() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.promote(555L);
+            assertThatThrownBy(waitlist::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+        }
+
+        @Test
+        void CANCELLED에서_cancel_시_ALREADY_CANCELLED() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.cancel();
+            assertThatThrownBy(waitlist::cancel)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_CANCELLED));
+        }
+    }
+
+    @Nested
+    class Skip {
+
+        @Test
+        void skip_시_예외_없이_CANCELLED로_전환() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.skip();
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(waitlist.getCancelledAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class ValidateOwner {
+
+        @Test
+        void 소유자_일치_시_예외_없음() {
+            Waitlist waitlist = newWaitlist();
+            waitlist.validateOwner(2L);
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_WAITLIST_OWNER_예외() {
+            Waitlist waitlist = newWaitlist();
+            assertThatThrownBy(() -> waitlist.validateOwner(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_WAITLIST_OWNER));
+        }
+    }
+
+    private Waitlist newWaitlist() {
+        return Waitlist.builder()
+                .classEntity(openClass)
+                .user(classmate)
+                .status(WaitlistStatus.WAITING)
+                .build();
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        Field field = obj.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(obj, id);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/repository/WaitlistRepositoryTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/repository/WaitlistRepositoryTest.java
@@ -1,0 +1,213 @@
+package com.enrollment.domain.waitlist.repository;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.global.config.JpaAuditingConfig;
+import com.enrollment.support.AbstractIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Import(JpaAuditingConfig.class)
+class WaitlistRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    TestEntityManager em;
+    @Autowired
+    WaitlistRepository waitlistRepository;
+    @Autowired
+    ClassRepository classRepository;
+    @Autowired
+    UserRepository userRepository;
+
+    private User creator;
+    private User classmate;
+    private User otherClassmate;
+    private ClassEntity fullClass;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.saveAndFlush(
+                User.builder().name("instructor").role(UserRole.CREATOR).build()
+        );
+        classmate = userRepository.saveAndFlush(
+                User.builder().name("student").role(UserRole.CLASSMATE).build()
+        );
+        otherClassmate = userRepository.saveAndFlush(
+                User.builder().name("other").role(UserRole.CLASSMATE).build()
+        );
+        fullClass = classRepository.saveAndFlush(
+                ClassEntity.builder()
+                        .createdBy(creator)
+                        .title("Java 기초").description("설명")
+                        .price(10000).capacity(1).enrolledCount(1)
+                        .startDate(LocalDate.of(2025, 3, 1))
+                        .endDate(LocalDate.of(2025, 6, 30))
+                        .status(ClassStatus.OPEN)
+                        .build()
+        );
+    }
+
+    @Test
+    void save_시_id_자동_생성_및_auditing() {
+        Waitlist saved = waitlistRepository.saveAndFlush(newWaiting(classmate));
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+        assertThat(saved.getStatus()).isEqualTo(WaitlistStatus.WAITING);
+    }
+
+    @Test
+    void 부분_유니크_인덱스_WAITING_중복_방지() {
+        waitlistRepository.saveAndFlush(newWaiting(classmate));
+        em.clear();
+
+        Waitlist duplicate = newWaiting(classmate);
+        assertThatThrownBy(() -> waitlistRepository.saveAndFlush(duplicate))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 부분_유니크_인덱스_CANCELLED_후_재등록_허용() {
+        Waitlist first = waitlistRepository.saveAndFlush(newWaiting(classmate));
+        first.cancel();
+        waitlistRepository.saveAndFlush(first);
+        em.clear();
+
+        Waitlist secondAttempt = newWaiting(classmate);
+        Waitlist saved = waitlistRepository.saveAndFlush(secondAttempt);
+        assertThat(saved.getId()).isNotNull();
+    }
+
+    @Test
+    void chk_waitlist_promotion_PROMOTED인데_promoted_at_NULL이면_실패() throws Exception {
+        // JPA 라이프사이클을 우회하기 위해 리플렉션으로 필드 직접 설정 후 flush
+        Waitlist waitlist = newWaiting(classmate);
+        setField(waitlist, "status", WaitlistStatus.PROMOTED);
+        setField(waitlist, "promotedEnrollmentId", null);
+        setField(waitlist, "promotedAt", null);
+
+        assertThatThrownBy(() -> waitlistRepository.saveAndFlush(waitlist))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void chk_waitlist_cancelled_CANCELLED인데_cancelled_at_NULL이면_실패() throws Exception {
+        Waitlist waitlist = newWaiting(classmate);
+        setField(waitlist, "status", WaitlistStatus.CANCELLED);
+        setField(waitlist, "cancelledAt", null);
+
+        assertThatThrownBy(() -> waitlistRepository.saveAndFlush(waitlist))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void findFirstWaitingForUpdate_FIFO_순서로_선두_조회() throws Exception {
+        // 타이브레이커 확인 위해 createdAt을 동일하게 강제 설정
+        Waitlist first = waitlistRepository.saveAndFlush(newWaiting(classmate));
+        Waitlist second = waitlistRepository.saveAndFlush(newWaiting(otherClassmate));
+
+        LocalDateTime sameInstant = LocalDateTime.now();
+        setField(first, "createdAt", sameInstant);
+        setField(second, "createdAt", sameInstant);
+        waitlistRepository.saveAndFlush(first);
+        waitlistRepository.saveAndFlush(second);
+        em.clear();
+
+        Optional<Waitlist> found = waitlistRepository.findFirstWaitingForUpdate(fullClass.getId());
+        assertThat(found).isPresent();
+        // id 타이브레이커로 더 작은 id(first)가 선두
+        assertThat(found.get().getId()).isEqualTo(first.getId());
+        // JOIN FETCH로 user 즉시 로딩
+        assertThat(found.get().getUser().getName()).isEqualTo("student");
+    }
+
+    @Test
+    void findFirstWaitingForUpdate_createdAt_ASC_정렬() throws Exception {
+        Waitlist earlier = waitlistRepository.saveAndFlush(newWaiting(classmate));
+        Waitlist later = waitlistRepository.saveAndFlush(newWaiting(otherClassmate));
+
+        LocalDateTime base = LocalDateTime.now();
+        setField(earlier, "createdAt", base.minusMinutes(5));
+        setField(later, "createdAt", base);
+        waitlistRepository.saveAndFlush(earlier);
+        waitlistRepository.saveAndFlush(later);
+        em.clear();
+
+        Optional<Waitlist> found = waitlistRepository.findFirstWaitingForUpdate(fullClass.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(earlier.getId());
+    }
+
+    @Test
+    void existsByClassIdAndUserIdAndStatus_WAITING_존재하면_true() {
+        waitlistRepository.saveAndFlush(newWaiting(classmate));
+        em.clear();
+
+        boolean exists = waitlistRepository.existsByClassIdAndUserIdAndStatus(
+                fullClass.getId(), classmate.getId(), WaitlistStatus.WAITING);
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void existsByClassIdAndUserIdAndStatus_미존재시_false() {
+        boolean exists = waitlistRepository.existsByClassIdAndUserIdAndStatus(
+                fullClass.getId(), classmate.getId(), WaitlistStatus.WAITING);
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    void findByClassIdAndUserIdAndStatus_조회_성공() {
+        waitlistRepository.saveAndFlush(newWaiting(classmate));
+        em.clear();
+
+        Optional<Waitlist> found = waitlistRepository.findByClassIdAndUserIdAndStatus(
+                fullClass.getId(), classmate.getId(), WaitlistStatus.WAITING);
+        assertThat(found).isPresent();
+    }
+
+    private Waitlist newWaiting(User user) {
+        return Waitlist.builder()
+                .classEntity(fullClass)
+                .user(user)
+                .status(WaitlistStatus.WAITING)
+                .build();
+    }
+
+    private void setField(Object obj, String name, Object value) throws Exception {
+        Class<?> clazz = obj.getClass();
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField(name);
+                field.setAccessible(true);
+                field.set(obj, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/domain/waitlist/service/WaitlistServiceTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/domain/waitlist/service/WaitlistServiceTest.java
@@ -1,0 +1,401 @@
+package com.enrollment.domain.waitlist.service;
+
+import com.enrollment.domain.classes.entity.ClassEntity;
+import com.enrollment.domain.classes.entity.ClassStatus;
+import com.enrollment.domain.classes.repository.ClassRepository;
+import com.enrollment.domain.enrollment.entity.Enrollment;
+import com.enrollment.domain.enrollment.entity.EnrollmentStatus;
+import com.enrollment.domain.enrollment.repository.EnrollmentRepository;
+import com.enrollment.domain.user.entity.User;
+import com.enrollment.domain.user.entity.UserRole;
+import com.enrollment.domain.user.repository.UserRepository;
+import com.enrollment.domain.waitlist.dto.WaitlistResponse;
+import com.enrollment.domain.waitlist.entity.Waitlist;
+import com.enrollment.domain.waitlist.entity.WaitlistStatus;
+import com.enrollment.domain.waitlist.repository.WaitlistRepository;
+import com.enrollment.global.error.exception.BusinessException;
+import com.enrollment.global.error.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class WaitlistServiceTest {
+
+    @Mock
+    WaitlistRepository waitlistRepository;
+    @Mock
+    EnrollmentRepository enrollmentRepository;
+    @Mock
+    ClassRepository classRepository;
+    @Mock
+    UserRepository userRepository;
+    @InjectMocks
+    WaitlistService waitlistService;
+
+    private User creator;
+    private User classmate;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        creator = User.builder().name("instructor").role(UserRole.CREATOR).build();
+        setId(creator, 1L);
+        classmate = User.builder().name("student").role(UserRole.CLASSMATE).build();
+        setId(classmate, 2L);
+    }
+
+    private ClassEntity fullOpenClass(int capacity) throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(capacity).enrolledCount(capacity)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        entity.publish();
+        return entity;
+    }
+
+    private ClassEntity openClassWithVacancy() throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(30).enrolledCount(5)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        entity.publish();
+        return entity;
+    }
+
+    private ClassEntity closedClass() throws Exception {
+        ClassEntity entity = ClassEntity.builder()
+                .createdBy(creator)
+                .title("Java 기초").description("설명")
+                .price(10000).capacity(1).enrolledCount(1)
+                .startDate(LocalDate.of(2025, 3, 1))
+                .endDate(LocalDate.of(2025, 6, 30))
+                .status(ClassStatus.DRAFT).build();
+        setId(entity, 10L);
+        entity.publish();
+        entity.close();
+        return entity;
+    }
+
+    @Nested
+    class Register {
+
+        @Test
+        void 정상_등록() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(fullClass));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 2L)).willReturn(false);
+            given(waitlistRepository.existsByClassIdAndUserIdAndStatus(
+                    10L, 2L, WaitlistStatus.WAITING)).willReturn(false);
+
+            given(waitlistRepository.save(any(Waitlist.class))).willAnswer(inv -> {
+                Waitlist w = inv.getArgument(0);
+                setId(w, 500L);
+                return w;
+            });
+
+            WaitlistResponse response = waitlistService.register(2L, 10L);
+
+            assertThat(response.waitlistId()).isEqualTo(500L);
+            assertThat(response.classId()).isEqualTo(10L);
+            assertThat(response.classTitle()).isEqualTo("Java 기초");
+            assertThat(response.status()).isEqualTo("WAITING");
+        }
+
+        @Test
+        void 사용자_미존재_시_USER_NOT_FOUND() {
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> waitlistService.register(999L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+
+        @Test
+        void 강의_미존재_시_CLASS_NOT_FOUND() {
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CLASS_NOT_FOUND));
+        }
+
+        @Test
+        void 강의_OPEN_아니면_WAITLIST_NOT_ALLOWED() throws Exception {
+            ClassEntity closed = closedClass();
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(closed));
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.WAITLIST_NOT_ALLOWED));
+        }
+
+        @Test
+        void 정원_남으면_WAITLIST_NOT_ALLOWED() throws Exception {
+            ClassEntity withVacancy = openClassWithVacancy();
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(withVacancy));
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.WAITLIST_NOT_ALLOWED));
+        }
+
+        @Test
+        void 이미_활성_수강_신청이면_ALREADY_ENROLLED() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(fullClass));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 2L)).willReturn(true);
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_ENROLLED));
+        }
+
+        @Test
+        void 이미_대기중이면_ALREADY_IN_WAITLIST() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            given(userRepository.findById(2L)).willReturn(Optional.of(classmate));
+            given(classRepository.findById(10L)).willReturn(Optional.of(fullClass));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 2L)).willReturn(false);
+            given(waitlistRepository.existsByClassIdAndUserIdAndStatus(
+                    10L, 2L, WaitlistStatus.WAITING)).willReturn(true);
+
+            assertThatThrownBy(() -> waitlistService.register(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_IN_WAITLIST));
+        }
+    }
+
+    @Nested
+    class CancelWaitlist {
+
+        @Test
+        void 정상_철회() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            Waitlist waitlist = Waitlist.builder()
+                    .classEntity(fullClass).user(classmate)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(waitlist, 500L);
+
+            given(waitlistRepository.findByClassIdAndUserIdAndStatus(
+                    10L, 2L, WaitlistStatus.WAITING)).willReturn(Optional.of(waitlist));
+
+            waitlistService.cancelWaitlist(2L, 10L);
+
+            assertThat(waitlist.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(waitlist.getCancelledAt()).isNotNull();
+        }
+
+        @Test
+        void 대기열_미존재_시_WAITLIST_NOT_FOUND() {
+            given(waitlistRepository.findByClassIdAndUserIdAndStatus(
+                    10L, 2L, WaitlistStatus.WAITING)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> waitlistService.cancelWaitlist(2L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.WAITLIST_NOT_FOUND));
+        }
+
+        @Test
+        void 소유자_불일치_시_NOT_WAITLIST_OWNER() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            Waitlist waitlist = Waitlist.builder()
+                    .classEntity(fullClass).user(classmate)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(waitlist, 500L);
+
+            given(waitlistRepository.findByClassIdAndUserIdAndStatus(
+                    10L, 999L, WaitlistStatus.WAITING)).willReturn(Optional.of(waitlist));
+
+            assertThatThrownBy(() -> waitlistService.cancelWaitlist(999L, 10L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.NOT_WAITLIST_OWNER));
+        }
+    }
+
+    @Nested
+    class PromoteNext {
+
+        @Test
+        void 대기열_비어있으면_no_op() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            // cancel 이후 상태로 만들기 위해 정원 1 감소
+            setField(fullClass, "enrolledCount", 0);
+
+            given(waitlistRepository.findFirstWaitingForUpdate(10L)).willReturn(Optional.empty());
+
+            waitlistService.promoteNext(fullClass);
+
+            verify(enrollmentRepository, never()).save(any(Enrollment.class));
+            assertThat(fullClass.getEnrolledCount()).isEqualTo(0);
+        }
+
+        @Test
+        void 선두_승격_시_PENDING_신청_생성_및_enrolledCount_증가() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            setField(fullClass, "enrolledCount", 0);
+
+            User waitingUser = User.builder().name("waiter").role(UserRole.CLASSMATE).build();
+            setId(waitingUser, 3L);
+            Waitlist head = Waitlist.builder()
+                    .classEntity(fullClass).user(waitingUser)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(head, 500L);
+
+            given(waitlistRepository.findFirstWaitingForUpdate(10L)).willReturn(Optional.of(head));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 3L)).willReturn(false);
+            AtomicLong idGen = new AtomicLong(777);
+            given(enrollmentRepository.save(any(Enrollment.class))).willAnswer(inv -> {
+                Enrollment e = inv.getArgument(0);
+                setId(e, idGen.getAndIncrement());
+                return e;
+            });
+
+            waitlistService.promoteNext(fullClass);
+
+            ArgumentCaptor<Enrollment> captor = ArgumentCaptor.forClass(Enrollment.class);
+            verify(enrollmentRepository).save(captor.capture());
+            Enrollment saved = captor.getValue();
+            assertThat(saved.getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+            assertThat(saved.getUser().getId()).isEqualTo(3L);
+            assertThat(saved.getEnrolledAt()).isNotNull();
+
+            assertThat(head.getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+            assertThat(head.getPromotedEnrollmentId()).isEqualTo(777L);
+            assertThat(fullClass.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 선두_1명_skip_후_다음_승격() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            setField(fullClass, "enrolledCount", 0);
+
+            User skipUser = User.builder().name("skip").role(UserRole.CLASSMATE).build();
+            setId(skipUser, 3L);
+            User secondUser = User.builder().name("second").role(UserRole.CLASSMATE).build();
+            setId(secondUser, 4L);
+
+            Waitlist skipHead = Waitlist.builder()
+                    .classEntity(fullClass).user(skipUser)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(skipHead, 500L);
+            Waitlist secondHead = Waitlist.builder()
+                    .classEntity(fullClass).user(secondUser)
+                    .status(WaitlistStatus.WAITING).build();
+            setId(secondHead, 501L);
+
+            given(waitlistRepository.findFirstWaitingForUpdate(10L))
+                    .willReturn(Optional.of(skipHead))
+                    .willReturn(Optional.of(secondHead));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 3L)).willReturn(true);
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 4L)).willReturn(false);
+            given(enrollmentRepository.save(any(Enrollment.class))).willAnswer(inv -> {
+                Enrollment e = inv.getArgument(0);
+                setId(e, 888L);
+                return e;
+            });
+
+            waitlistService.promoteNext(fullClass);
+
+            assertThat(skipHead.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(secondHead.getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+            assertThat(fullClass.getEnrolledCount()).isEqualTo(1);
+        }
+
+        @Test
+        void 선두_2명_연속_skip_후_3번째_승격() throws Exception {
+            ClassEntity fullClass = fullOpenClass(1);
+            setField(fullClass, "enrolledCount", 0);
+
+            User a = User.builder().name("a").role(UserRole.CLASSMATE).build();
+            setId(a, 3L);
+            User b = User.builder().name("b").role(UserRole.CLASSMATE).build();
+            setId(b, 4L);
+            User c = User.builder().name("c").role(UserRole.CLASSMATE).build();
+            setId(c, 5L);
+
+            Waitlist wa = Waitlist.builder().classEntity(fullClass).user(a).status(WaitlistStatus.WAITING).build();
+            setId(wa, 500L);
+            Waitlist wb = Waitlist.builder().classEntity(fullClass).user(b).status(WaitlistStatus.WAITING).build();
+            setId(wb, 501L);
+            Waitlist wc = Waitlist.builder().classEntity(fullClass).user(c).status(WaitlistStatus.WAITING).build();
+            setId(wc, 502L);
+
+            given(waitlistRepository.findFirstWaitingForUpdate(10L))
+                    .willReturn(Optional.of(wa))
+                    .willReturn(Optional.of(wb))
+                    .willReturn(Optional.of(wc));
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 3L)).willReturn(true);
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 4L)).willReturn(true);
+            given(enrollmentRepository.existsActiveByClassIdAndUserId(10L, 5L)).willReturn(false);
+            given(enrollmentRepository.save(any(Enrollment.class))).willAnswer(inv -> {
+                Enrollment e = inv.getArgument(0);
+                setId(e, 999L);
+                return e;
+            });
+
+            waitlistService.promoteNext(fullClass);
+
+            assertThat(wa.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(wb.getStatus()).isEqualTo(WaitlistStatus.CANCELLED);
+            assertThat(wc.getStatus()).isEqualTo(WaitlistStatus.PROMOTED);
+            assertThat(fullClass.getEnrolledCount()).isEqualTo(1);
+        }
+    }
+
+    private void setId(Object obj, Long id) throws Exception {
+        setField(obj, "id", id);
+    }
+
+    private static void setField(Object obj, String name, Object value) throws Exception {
+        Class<?> clazz = obj.getClass();
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField(name);
+                field.setAccessible(true);
+                field.set(obj, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+}

--- a/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.*;
 
 import com.enrollment.domain.classes.service.ClassService;
+import com.enrollment.domain.enrollment.service.EnrollmentService;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -30,6 +31,8 @@ class GlobalExceptionHandlerTest {
     MockMvc mockMvc;
     @MockBean
     ClassService classService;
+    @MockBean
+    EnrollmentService enrollmentService;
 
     @Test
     void BusinessException_시_ErrorCode의_HttpStatus와_포맷으로_응답() throws Exception {

--- a/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import com.enrollment.domain.classes.service.ClassService;
 import com.enrollment.domain.enrollment.service.EnrollmentService;
+import com.enrollment.domain.waitlist.service.WaitlistService;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,6 +34,8 @@ class GlobalExceptionHandlerTest {
     ClassService classService;
     @MockBean
     EnrollmentService enrollmentService;
+    @MockBean
+    WaitlistService waitlistService;
 
     @Test
     void BusinessException_시_ErrorCode의_HttpStatus와_포맷으로_응답() throws Exception {

--- a/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/global/error/GlobalExceptionHandlerTest.java
@@ -8,10 +8,13 @@ import jakarta.validation.constraints.Positive;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.*;
+
+import com.enrollment.domain.classes.service.ClassService;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -25,6 +28,8 @@ class GlobalExceptionHandlerTest {
 
     @Autowired
     MockMvc mockMvc;
+    @MockBean
+    ClassService classService;
 
     @Test
     void BusinessException_시_ErrorCode의_HttpStatus와_포맷으로_응답() throws Exception {
@@ -55,6 +60,13 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.path").value("/test/unexpected"));
     }
 
+    @Test
+    void PropertyReferenceException_시_400_INVALID_INPUT() throws Exception {
+        mockMvc.perform(get("/test/bad-sort"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
     @RestController
     @RequestMapping("/test")
     static class TestController {
@@ -71,6 +83,14 @@ class GlobalExceptionHandlerTest {
         @GetMapping("/unexpected")
         public void unexpected() {
             throw new IllegalStateException("boom");
+        }
+
+        @GetMapping("/bad-sort")
+        public void badSort() {
+            throw new org.springframework.data.mapping.PropertyReferenceException(
+                    "[\"string\"]",
+                    org.springframework.data.util.TypeInformation.of(Object.class),
+                    java.util.Collections.emptyList());
         }
 
         record Payload(@NotBlank String title, @Positive int price) {

--- a/enrollment-api/src/test/java/com/enrollment/support/AbstractIntegrationTest.java
+++ b/enrollment-api/src/test/java/com/enrollment/support/AbstractIntegrationTest.java
@@ -1,0 +1,15 @@
+package com.enrollment.support;
+
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public abstract class AbstractIntegrationTest {
+
+    @ServiceConnection
+    protected static final PostgreSQLContainer<?> POSTGRES =
+        new PostgreSQLContainer<>("postgres:15-alpine");
+
+    static {
+        POSTGRES.start();
+    }
+}

--- a/enrollment-api/src/test/resources/application.yml
+++ b/enrollment-api/src/test/resources/application.yml
@@ -1,6 +1,0 @@
-spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration


### PR DESCRIPTION
## Summary
User / Class / Enrollment / Waitlist / TTL 기능 전체 develop 검증 완료, main 릴리스.

## 포함 PR
- #11 [feat] User 도메인 + JPA 인프라 기반 구축 (close #10)
- #13 [feat] Class(강의) 도메인 구현 (close #12)
- #15 [feat] Enrollment(수강 신청) 도메인 + 결제 시뮬레이션 구현 (close #14)
- #17 [feat] 대기열(Waitlist) 기능 구현 (close #16)
- #19 [feat] PENDING TTL 만료 + 승격 알림 구현 (close #18)

## 검증
- [x] develop 빌드 성공
- [x] 전체 226 tests, 0 failures
- [x] Testcontainers 기반 통합/동시성 테스트 통과
- [x] Swagger UI 렌더링, 전체 엔드포인트 응답 확인

## DB 마이그레이션
- V2 ~ V7 전체 순차 적용 (classes, seed_users, enrollments, payments, waitlists, enrollments.expires_at)
- prod 환경(`ddl-auto: validate`)에서는 Flyway가 자동 적용
